### PR TITLE
Connect PriceFeed to `manage-position` Components

### DIFF
--- a/features/contract-state/GeneralInfo.tsx
+++ b/features/contract-state/GeneralInfo.tsx
@@ -7,6 +7,7 @@ import Collateral from "../../containers/Collateral";
 import Token from "../../containers/Token";
 import EmpContract from "../../containers/EmpContract";
 import Totals from "../../containers/Totals";
+import PriceFeed from "../../containers/PriceFeed";
 
 const Label = styled.span`
   color: #999999;
@@ -29,6 +30,7 @@ const GeneralInfo = () => {
   const { contract } = EmpContract.useContainer();
   const { empState } = EmpState.useContainer();
   const { gcr } = Totals.useContainer();
+  const { latestPrice } = PriceFeed.useContainer();
 
   const {
     expirationTimestamp: expiry,
@@ -41,6 +43,8 @@ const GeneralInfo = () => {
 
   // format nice date
   const expiryDate = expiry ? new Date(expiry.toNumber() * 1000) : "N/A";
+
+  const pricedGcr = gcr && latestPrice ? gcr / Number(latestPrice) : null;
 
   return (
     <Box>
@@ -89,7 +93,7 @@ const GeneralInfo = () => {
         <Tooltip
           title={`The Global Collateralization Ratio (GCR) is the ratio of the total amount of collateral to total number of outstanding tokens.`}
         >
-          <span>{gcr ? gcr : "N/A"}</span>
+          <span>{pricedGcr ? pricedGcr.toFixed(4) : "N/A"}</span>
         </Tooltip>
       </Status>
     </Box>

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -125,7 +125,7 @@ const Create = () => {
     // all values non-null, proceed to calculate
     const totalCollateral = posCollateral + parseFloat(collateral);
     const totalTokens = posTokens + parseFloat(tokens);
-    return totalCollateral / (totalTokens * Number(latestPrice));
+    return totalCollateral / totalTokens;
   };
   const computedCR = computeCR() || 0;
 

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -9,6 +9,7 @@ import Token from "../../containers/Token";
 import EmpState from "../../containers/EmpState";
 import Totals from "../../containers/Totals";
 import Position from "../../containers/Position";
+import PriceFeed from "../../containers/PriceFeed";
 
 import { useEtherscanUrl } from "../../utils/useEtherscanUrl";
 
@@ -46,6 +47,7 @@ const Create = () => {
     tokens: posTokens,
     pendingWithdraw,
   } = Position.useContainer();
+  const { latestPrice } = PriceFeed.useContainer();
 
   const [collateral, setCollateral] = useState<string>("");
   const [tokens, setTokens] = useState<string>("");
@@ -115,17 +117,19 @@ const Create = () => {
       collateral === null ||
       tokens === null ||
       posCollateral === null ||
-      posTokens === null
+      posTokens === null ||
+      latestPrice === null
     )
       return null;
 
     // all values non-null, proceed to calculate
     const totalCollateral = posCollateral + parseFloat(collateral);
     const totalTokens = posTokens + parseFloat(tokens);
-    return totalCollateral / totalTokens;
+    return totalCollateral / (totalTokens * Number(latestPrice));
   };
 
   const computedCR = computeCR() || 0;
+  const computedGCR = gcr && latestPrice ? gcr / Number(latestPrice) : null;
 
   const etherscanUrl = useEtherscanUrl(hash);
 
@@ -262,7 +266,7 @@ const Create = () => {
         ) : (
           <Typography>Resulting CR: N/A</Typography>
         )}
-        <Typography>Current GCR: {gcr || "N/A"}</Typography>
+        <Typography>Current GCR: {computedGCR || "N/A"}</Typography>
       </Box>
 
       {hash && (

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -262,13 +262,13 @@ const Create = () => {
           <Typography>
             Resulting CR:{" "}
             <span style={{ color: computedCR < gcr ? "red" : "unset" }}>
-              {pricedCR}
+              {pricedCR?.toFixed(4)}
             </span>
           </Typography>
         ) : (
           <Typography>Resulting CR: N/A</Typography>
         )}
-        <Typography>Current GCR: {pricedGCR || "N/A"}</Typography>
+        <Typography>Current GCR: {pricedGCR?.toFixed(4) || "N/A"}</Typography>
       </Box>
 
       {hash && (

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -127,9 +127,11 @@ const Create = () => {
     const totalTokens = posTokens + parseFloat(tokens);
     return totalCollateral / (totalTokens * Number(latestPrice));
   };
-
   const computedCR = computeCR() || 0;
-  const computedGCR = gcr && latestPrice ? gcr / Number(latestPrice) : null;
+
+  const pricedCR =
+    computedCR && latestPrice ? computedCR / Number(latestPrice) : null;
+  const pricedGCR = gcr && latestPrice ? gcr / Number(latestPrice) : null;
 
   const etherscanUrl = useEtherscanUrl(hash);
 
@@ -260,13 +262,13 @@ const Create = () => {
           <Typography>
             Resulting CR:{" "}
             <span style={{ color: computedCR < gcr ? "red" : "unset" }}>
-              {computedCR}
+              {pricedCR}
             </span>
           </Typography>
         ) : (
           <Typography>Resulting CR: N/A</Typography>
         )}
-        <Typography>Current GCR: {computedGCR || "N/A"}</Typography>
+        <Typography>Current GCR: {pricedGCR || "N/A"}</Typography>
       </Box>
 
       {hash && (

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -6,6 +6,7 @@ import { ethers } from "ethers";
 import EmpContract from "../../containers/EmpContract";
 import Collateral from "../../containers/Collateral";
 import Position from "../../containers/Position";
+import PriceFeed from "../../containers/PriceFeed";
 
 import { useEtherscanUrl } from "../../utils/useEtherscanUrl";
 
@@ -22,6 +23,7 @@ const Deposit = () => {
   const { contract: emp } = EmpContract.useContainer();
   const { symbol: collSymbol, balance } = Collateral.useContainer();
   const { tokens, collateral, pendingWithdraw } = Position.useContainer();
+  const { latestPrice } = PriceFeed.useContainer();
 
   const [collateralToDeposit, setCollateralToDeposit] = useState<string>("");
   const [hash, setHash] = useState<string | null>(null);
@@ -56,11 +58,15 @@ const Deposit = () => {
 
   const handleDepositClick = () => depositCollateral();
 
-  const startingCR = collateral && tokens ? collateral / tokens : null;
+  const startingCR =
+    collateral && tokens && latestPrice
+      ? collateral / (tokens * Number(latestPrice))
+      : null;
 
   const resultingCR =
-    collateral && collateralToDeposit && tokens
-      ? (collateral + parseFloat(collateralToDeposit)) / tokens
+    collateral && collateralToDeposit && tokens && latestPrice
+      ? (collateral + parseFloat(collateralToDeposit)) /
+        (tokens * Number(latestPrice))
       : startingCR;
 
   // User does not have a position yet.

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -59,15 +59,16 @@ const Deposit = () => {
   const handleDepositClick = () => depositCollateral();
 
   const startingCR =
-    collateral && tokens && latestPrice
-      ? collateral / (tokens * Number(latestPrice))
-      : null;
+    collateral && tokens && latestPrice ? collateral / tokens : null;
+  const pricedStartingCR =
+    startingCR && latestPrice ? startingCR / Number(latestPrice) : null;
 
   const resultingCR =
     collateral && collateralToDeposit && tokens && latestPrice
-      ? (collateral + parseFloat(collateralToDeposit)) /
-        (tokens * Number(latestPrice))
+      ? (collateral + parseFloat(collateralToDeposit)) / tokens
       : startingCR;
+  const pricedResultingCR =
+    resultingCR && latestPrice ? resultingCR / Number(latestPrice) : null;
 
   // User does not have a position yet.
   if (collateral === null || collateral.toString() === "0") {
@@ -136,8 +137,8 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        <Typography>Current CR: {startingCR || "N/A"}</Typography>
-        <Typography>Resulting CR: {resultingCR || "N/A"}</Typography>
+        <Typography>Current CR: {pricedStartingCR || "N/A"}</Typography>
+        <Typography>Resulting CR: {pricedResultingCR || "N/A"}</Typography>
       </Box>
 
       {hash && (

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -58,13 +58,12 @@ const Deposit = () => {
 
   const handleDepositClick = () => depositCollateral();
 
-  const startingCR =
-    collateral && tokens && latestPrice ? collateral / tokens : null;
+  const startingCR = collateral && tokens ? collateral / tokens : null;
   const pricedStartingCR =
     startingCR && latestPrice ? startingCR / Number(latestPrice) : null;
 
   const resultingCR =
-    collateral && collateralToDeposit && tokens && latestPrice
+    collateral && collateralToDeposit && tokens
       ? (collateral + parseFloat(collateralToDeposit)) / tokens
       : startingCR;
   const pricedResultingCR =

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -136,8 +136,12 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        <Typography>Current CR: {pricedStartingCR || "N/A"}</Typography>
-        <Typography>Resulting CR: {pricedResultingCR || "N/A"}</Typography>
+        <Typography>
+          Current CR: {pricedStartingCR?.toFixed(4) || "N/A"}
+        </Typography>
+        <Typography>
+          Resulting CR: {pricedResultingCR?.toFixed(4) || "N/A"}
+        </Typography>
       </Box>
 
       {hash && (

--- a/features/manage-position/ManagePosition.tsx
+++ b/features/manage-position/ManagePosition.tsx
@@ -8,6 +8,7 @@ import Deposit from "./Deposit";
 import Redeem from "./Redeem";
 import Withdraw from "./Withdraw";
 import YourPosition from "./YourPosition";
+import YourWallet from "./YourWallet";
 
 export type Method = "create" | "deposit" | "withdraw" | "redeem" | "transfer";
 
@@ -33,6 +34,7 @@ const Manager = () => {
 
   return (
     <Box my={0}>
+      <YourWallet />
       <YourPosition />
       <MethodSelector method={method} handleChange={handleChange} />
 

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -8,6 +8,7 @@ import EmpContract from "../../containers/EmpContract";
 import Collateral from "../../containers/Collateral";
 import Position from "../../containers/Position";
 import Totals from "../../containers/Totals";
+import PriceFeed from "../../containers/PriceFeed";
 
 import { useEtherscanUrl } from "../../utils/useEtherscanUrl";
 
@@ -40,6 +41,7 @@ const Deposit = () => {
     pendingWithdraw,
   } = Position.useContainer();
   const { gcr } = Totals.useContainer();
+  const { latestPrice } = PriceFeed.useContainer();
 
   const [collateralToWithdraw, setCollateralToWithdraw] = useState<string>("");
   const [hash, setHash] = useState<string | null>(null);
@@ -122,27 +124,31 @@ const Deposit = () => {
   const handleExecuteWithdrawClick = () => executeWithdraw();
   const handleCancelWithdrawClick = () => cancelWithdraw();
 
+  // Calculations using raw collateral ratios:
   const startingCR = collateral && tokens ? collateral / tokens : null;
-
   const resultingCR =
     collateral && collateralToWithdraw && tokens
       ? (collateral - parseFloat(collateralToWithdraw)) / tokens
       : startingCR;
-
   const resultingCRBelowGCR = resultingCR && gcr ? resultingCR < gcr : null;
-
   const fastWithdrawableCollateral =
     collateral && tokens && gcr ? (collateral - gcr * tokens).toFixed(2) : null;
 
+  // Calculations of collateral ratios using same units as price feed:
+  const pricedStartingCR =
+    startingCR && latestPrice ? startingCR / Number(latestPrice) : null;
+  const pricedResultingCR =
+    resultingCR && latestPrice ? resultingCR / Number(latestPrice) : null;
+  const pricedGcr = gcr && latestPrice ? gcr / Number(latestPrice) : null;
+
+  // Pending withdrawal request information:
   const pendingWithdrawTimeRemaining =
     collateral && withdrawPassTime && pendingWithdraw === "Yes"
       ? withdrawPassTime - Math.floor(Date.now() / 1000) - 7200
       : null;
-
   const pastWithdrawTimeStamp = pendingWithdrawTimeRemaining
     ? pendingWithdrawTimeRemaining <= 0
     : null;
-
   const pendingWithdrawTimeString = pendingWithdrawTimeRemaining
     ? Math.max(0, Math.floor(pendingWithdrawTimeRemaining / 3600)) +
       ":" +
@@ -150,6 +156,7 @@ const Deposit = () => {
       ":" +
       Math.max(0, (pendingWithdrawTimeRemaining % 3600) % 60)
     : null;
+
   // User does not have a position yet.
   if (collateral === null || collateral.toString() === "0") {
     return (
@@ -298,9 +305,13 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        <Typography>Current global CR: {gcr || "N/A"}</Typography>
-        <Typography>Current position CR: {startingCR || "N/A"}</Typography>
-        <Typography>Resulting position CR: {resultingCR || "N/A"}</Typography>
+        <Typography>Current global CR: {pricedGcr || "N/A"}</Typography>
+        <Typography>
+          Current position CR: {pricedStartingCR || "N/A"}
+        </Typography>
+        <Typography>
+          Resulting position CR: {pricedResultingCR || "N/A"}
+        </Typography>
         {collateralToWithdraw && collateralToWithdraw != "0" ? (
           resultingCRBelowGCR ? (
             <Typography style={{ color: "red" }}>

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -305,12 +305,14 @@ const Deposit = () => {
       </Box>
 
       <Box py={2}>
-        <Typography>Current global CR: {pricedGcr || "N/A"}</Typography>
         <Typography>
-          Current position CR: {pricedStartingCR || "N/A"}
+          Current global CR: {pricedGcr?.toFixed(4) || "N/A"}
         </Typography>
         <Typography>
-          Resulting position CR: {pricedResultingCR || "N/A"}
+          Current position CR: {pricedStartingCR?.toFixed(4) || "N/A"}
+        </Typography>
+        <Typography>
+          Resulting position CR: {pricedResultingCR?.toFixed(4) || "N/A"}
         </Typography>
         {collateralToWithdraw && collateralToWithdraw != "0" ? (
           resultingCRBelowGCR ? (

--- a/features/manage-position/YourPosition.tsx
+++ b/features/manage-position/YourPosition.tsx
@@ -5,6 +5,7 @@ import Position from "../../containers/Position";
 import Collateral from "../../containers/Collateral";
 import Token from "../../containers/Token";
 import Totals from "../../containers/Totals";
+import PriceFeed from "../../containers/PriceFeed";
 
 const Label = styled.span`
   color: #999999;
@@ -17,8 +18,13 @@ const Status = styled(Typography)`
 `;
 
 const Container = styled.div`
+  margin-top: 20px;
   padding: 1rem;
   border: 1px solid #434343;
+`;
+
+const Link = styled.a`
+  font-size: 14px;
 `;
 
 const YourPosition = () => {
@@ -32,15 +38,24 @@ const YourPosition = () => {
   } = Position.useContainer();
   const { symbol: collSymbol } = Collateral.useContainer();
   const { symbol: tokenSymbol } = Token.useContainer();
+  const { latestPrice, sourceUrl } = PriceFeed.useContainer();
 
   const ready =
     tokens !== null &&
     collateral !== null &&
     collSymbol !== null &&
-    tokenSymbol !== null;
+    tokenSymbol !== null &&
+    latestPrice !== null &&
+    sourceUrl;
 
-  const collateralzationRatio =
+  const collateralizationRatio =
     collateral !== null && tokens !== null ? collateral / tokens : null;
+  const pricedCollateralizationRatio =
+    collateralizationRatio !== null && latestPrice !== null
+      ? collateralizationRatio / Number(latestPrice)
+      : null;
+  const pricedGcr =
+    gcr !== null && latestPrice !== null ? gcr / Number(latestPrice) : null;
 
   return (
     <Container>
@@ -54,12 +69,28 @@ const YourPosition = () => {
         {ready ? `${tokens} ${tokenSymbol}` : "N/A"}
       </Status>
       <Status>
-        <Label>Collateralization ratio: </Label>
-        {ready ? collateralzationRatio : "N/A"}
+        <Label>
+          Estimated Token price (
+          <Link href={sourceUrl} target="_blank" rel="noopener noreferrer">
+            Coinbase Pro
+          </Link>
+          ):{" "}
+        </Label>
+        {ready ? `${latestPrice?.toLocaleString()}` : "N/A"}
       </Status>
       <Status>
-        <Label>Global collateralization ratio: </Label>
-        {ready ? gcr : "N/A"}
+        <Label>(CR) Collateralization ratio: </Label>
+        {pricedCollateralizationRatio
+          ? `${pricedCollateralizationRatio?.toFixed(
+              4
+            )} (${collSymbol} / ${tokenSymbol})`
+          : "N/A"}
+      </Status>
+      <Status>
+        <Label>(GCR) Global collateralization ratio: </Label>
+        {pricedGcr
+          ? `${pricedGcr?.toFixed(4)} (${collSymbol} / ${tokenSymbol})`
+          : "N/A"}
       </Status>
       <Status>
         <Label>Collateral pending/available to withdraw: </Label>

--- a/features/manage-position/YourWallet.tsx
+++ b/features/manage-position/YourWallet.tsx
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { Typography } from "@material-ui/core";
+
+import Collateral from "../../containers/Collateral";
+import Token from "../../containers/Token";
+import PriceFeed from "../../containers/PriceFeed";
+
+const Label = styled.span`
+  color: #999999;
+`;
+
+const Status = styled(Typography)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Container = styled.div`
+  padding: 1rem;
+  border: 1px solid #434343;
+`;
+
+const YourWallet = () => {
+  const {
+    symbol: collSymbol,
+    balance: collBalance,
+  } = Collateral.useContainer();
+  const { symbol: tokenSymbol, balance: tokenBalance } = Token.useContainer();
+  const { latestPrice, sourceUrl } = PriceFeed.useContainer();
+
+  const ready =
+    tokenBalance !== null &&
+    collBalance !== null &&
+    collSymbol !== null &&
+    tokenSymbol !== null &&
+    latestPrice !== null;
+
+  return (
+    <Container>
+      <Typography variant="h5">Your Wallet</Typography>
+      <Status>
+        <Label>Collateral balance: </Label>
+        {ready ? `${collBalance} ${collSymbol}` : "N/A"}
+      </Status>
+      <Status>
+        <Label>Token balance: </Label>
+        {ready ? `${tokenBalance} ${tokenSymbol}` : "N/A"}
+      </Status>
+    </Container>
+  );
+};
+
+export default YourWallet;


### PR DESCRIPTION
Divides CR and GCR by pricefeed's `latestPrice` wherever it is displayed to end user. I took care not to add in the `latestPrice` into existing CR calculations that determine whether the user can execute EMP position management actions. This is because these actions all happen on invisible to the user. Instead, I calculated new variables from the existing CR's and using the `latestPrice` and displayed these new "priced" CR's to the end user.

Resolves #13 

Signed-off-by: Nick Pai <npai.nyc@gmail.com>