### PR TITLE
Add dynamic links to exchanges to buy collateral or synthetic tokens

### DIFF
--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -6,6 +6,8 @@ import Collateral from "../../containers/Collateral";
 import Token from "../../containers/Token";
 import Etherscan from "../../containers/Etherscan";
 
+import { getExchangeLinkFuncFromTokenSymbol } from "../../utils/getExchangeLinks";
+
 const DataBox = styled(Box)`
   border: 1px solid #434343;
   padding: 1rem 2rem;
@@ -48,6 +50,8 @@ const Totals = () => {
   const { symbol: tokenSymbol, address: tokenAddress } = Token.useContainer();
   const { getEtherscanUrl } = Etherscan.useContainer();
 
+  const getExchangeLink = getExchangeLinkFuncFromTokenSymbol(tokenSymbol);
+
   const loading =
     !totalCollateral || !totalTokens || !collSymbol || !tokenSymbol;
   return (
@@ -75,13 +79,15 @@ const Totals = () => {
                 Etherscan
               </SmallLink>
             )}
-            <SmallLink
-              href={`https://uniswap.info/token/${collAddress}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Uniswap
-            </SmallLink>
+            {getExchangeLink !== undefined && collAddress && tokenAddress && (
+              <SmallLink
+                href={getExchangeLink.baseurl(collAddress)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {getExchangeLink.name}
+              </SmallLink>
+            )}
           </LinksContainer>
         </DataBox>
       </Grid>
@@ -111,13 +117,15 @@ const Totals = () => {
                 Etherscan
               </SmallLink>
             )}
-            <SmallLink
-              href={`https://uniswap.info/token/${tokenAddress}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Uniswap
-            </SmallLink>
+            {getExchangeLink !== undefined && collAddress && tokenAddress && (
+              <SmallLink
+                href={getExchangeLink.baseurl(tokenAddress)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {getExchangeLink.name}
+              </SmallLink>
+            )}
           </LinksContainer>
         </DataBox>
       </Grid>

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -6,7 +6,7 @@ import Collateral from "../../containers/Collateral";
 import Token from "../../containers/Token";
 import Etherscan from "../../containers/Etherscan";
 
-import { getExchangeLinkFuncFromTokenSymbol } from "../../utils/getExchangeLinks";
+import { getExchangeInfo } from "../../utils/getExchangeLinks";
 
 const DataBox = styled(Box)`
   border: 1px solid #434343;
@@ -50,7 +50,7 @@ const Totals = () => {
   const { symbol: tokenSymbol, address: tokenAddress } = Token.useContainer();
   const { getEtherscanUrl } = Etherscan.useContainer();
 
-  const getExchangeLink = getExchangeLinkFuncFromTokenSymbol(tokenSymbol);
+  const exchangeInfo = getExchangeInfo(tokenSymbol);
 
   const loading =
     !totalCollateral || !totalTokens || !collSymbol || !tokenSymbol;
@@ -79,13 +79,13 @@ const Totals = () => {
                 Etherscan
               </SmallLink>
             )}
-            {getExchangeLink !== undefined && collAddress && tokenAddress && (
+            {exchangeInfo !== undefined && collAddress && (
               <SmallLink
-                href={getExchangeLink.baseurl(collAddress)}
+                href={exchangeInfo.getExchangeUrl(collAddress)}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {getExchangeLink.name}
+                {exchangeInfo.name}
               </SmallLink>
             )}
           </LinksContainer>
@@ -117,13 +117,13 @@ const Totals = () => {
                 Etherscan
               </SmallLink>
             )}
-            {getExchangeLink !== undefined && collAddress && tokenAddress && (
+            {exchangeInfo !== undefined && tokenAddress && (
               <SmallLink
-                href={getExchangeLink.baseurl(tokenAddress)}
+                href={exchangeInfo.getExchangeUrl(tokenAddress)}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {getExchangeLink.name}
+                {exchangeInfo.name}
               </SmallLink>
             )}
           </LinksContainer>

--- a/utils/getExchangeLinks.ts
+++ b/utils/getExchangeLinks.ts
@@ -33,6 +33,7 @@ export const EXCHANGE_LINK_MAP: ExchangeLinkMap = {
     `https://uniswap.info/token/${tokenAddress}`,
   [EXCHANGES.BALANCER]: (tokenAddress) =>
     `https://balancer.exchange/#/swap/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/${tokenAddress}`,
+  // This returns a Balancer exchange URL to buy `tokenAddress` and sell USDC, a well understood currency
 };
 
 export const getExchangeTypeFromTokenSymbol = (symbol: string | null) => {

--- a/utils/getExchangeLinks.ts
+++ b/utils/getExchangeLinks.ts
@@ -11,7 +11,7 @@ export enum EXCHANGES {
   BALANCER,
 }
 
-export const EXCHANGE_NAMES: ExchangeNameMap = {
+export const EXCHANGE_NAMES_MAP: ExchangeNameMap = {
   [EXCHANGES.UNISWAP]: "Uniswap",
   [EXCHANGES.BALANCER]: "Balancer",
 };
@@ -30,7 +30,7 @@ export const TOKEN_TO_EXCHANGE_MAP: TokenExchangeMap = {
 
 export const EXCHANGE_LINK_MAP: ExchangeLinkMap = {
   [EXCHANGES.UNISWAP]: (tokenAddress) =>
-    `https://uniswap.info/token/${tokenAddress}`,
+    `https://app.uniswap.org/#/swap?outputCurrency=${tokenAddress}`,
   [EXCHANGES.BALANCER]: (tokenAddress) =>
     `https://balancer.exchange/#/swap/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/${tokenAddress}`,
   // This returns a Balancer exchange URL to buy `tokenAddress` and sell USDC, a well understood currency
@@ -49,12 +49,12 @@ export const getExchangeTypeFromTokenSymbol = (symbol: string | null) => {
   }
 };
 
-export const getExchangeLinkFuncFromTokenSymbol = (symbol: string | null) => {
+export const getExchangeInfo = (symbol: string | null) => {
   const exchangeType = getExchangeTypeFromTokenSymbol(symbol);
   if (exchangeType !== null) {
     return {
-      name: EXCHANGE_NAMES[exchangeType],
-      baseurl: EXCHANGE_LINK_MAP[exchangeType],
+      name: EXCHANGE_NAMES_MAP[exchangeType],
+      getExchangeUrl: EXCHANGE_LINK_MAP[exchangeType],
     };
   }
 };

--- a/utils/getExchangeLinks.ts
+++ b/utils/getExchangeLinks.ts
@@ -6,37 +6,38 @@ interface ExchangeNameMap {
   [exchangeType: number]: string;
 }
 
-export enum EXCHANGES {
-  UNISWAP,
-  BALANCER,
-}
-
-export const EXCHANGE_NAMES_MAP: ExchangeNameMap = {
-  [EXCHANGES.UNISWAP]: "Uniswap",
-  [EXCHANGES.BALANCER]: "Balancer",
-};
-
-// Returns a function for a given exchange that can be used to retrieve an exchange's specific swap URL for a chosen token.
 interface ExchangeLinkMap {
   [exchangeEnum: number]: (params: any) => string;
 }
 
-// A mapping of synthetic tokens to the exchange where they can be traded.
-export const TOKEN_TO_EXCHANGE_MAP: TokenExchangeMap = {
+enum EXCHANGES {
+  UNISWAP,
+  BALANCER,
+}
+
+const EXCHANGE_NAMES_MAP: ExchangeNameMap = {
+  [EXCHANGES.UNISWAP]: "Uniswap",
+  [EXCHANGES.BALANCER]: "Balancer",
+};
+
+// Maps synthetic tokens to the exchange where they and their collateral can be traded.
+const TOKEN_TO_EXCHANGE_MAP: TokenExchangeMap = {
   ycomp: EXCHANGES.UNISWAP,
   ethbtc: EXCHANGES.UNISWAP,
   yusd: EXCHANGES.BALANCER,
 };
 
-export const EXCHANGE_LINK_MAP: ExchangeLinkMap = {
+// Maps exchange types to functions that can be used to retrieve the exchange's swap URL for a chosen token.
+const EXCHANGE_LINK_MAP: ExchangeLinkMap = {
   [EXCHANGES.UNISWAP]: (tokenAddress) =>
     `https://app.uniswap.org/#/swap?outputCurrency=${tokenAddress}`,
   [EXCHANGES.BALANCER]: (tokenAddress) =>
     `https://balancer.exchange/#/swap/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/${tokenAddress}`,
-  // This returns a Balancer exchange URL to buy `tokenAddress` and sell USDC, a well understood currency
+  // Since two currencies must be specified to the Balancer server,
+  // This returns a Balancer exchange URL to swap `tokenAddress` and sell USDC, a well understood currency
 };
 
-export const getExchangeTypeFromTokenSymbol = (symbol: string | null) => {
+const _getExchangeTypeFromTokenSymbol = (symbol: string | null) => {
   switch (true) {
     case symbol?.includes("yCOMP"):
       return TOKEN_TO_EXCHANGE_MAP.ycomp;
@@ -50,7 +51,7 @@ export const getExchangeTypeFromTokenSymbol = (symbol: string | null) => {
 };
 
 export const getExchangeInfo = (symbol: string | null) => {
-  const exchangeType = getExchangeTypeFromTokenSymbol(symbol);
+  const exchangeType = _getExchangeTypeFromTokenSymbol(symbol);
   if (exchangeType !== null) {
     return {
       name: EXCHANGE_NAMES_MAP[exchangeType],

--- a/utils/getExchangeLinks.ts
+++ b/utils/getExchangeLinks.ts
@@ -1,0 +1,59 @@
+interface TokenExchangeMap {
+  [tokenSymbol: string]: number;
+}
+
+interface ExchangeNameMap {
+  [exchangeType: number]: string;
+}
+
+export enum EXCHANGES {
+  UNISWAP,
+  BALANCER,
+}
+
+export const EXCHANGE_NAMES: ExchangeNameMap = {
+  [EXCHANGES.UNISWAP]: "Uniswap",
+  [EXCHANGES.BALANCER]: "Balancer",
+};
+
+// Returns a function for a given exchange that can be used to retrieve an exchange's specific swap URL for a chosen token.
+interface ExchangeLinkMap {
+  [exchangeEnum: number]: (params: any) => string;
+}
+
+// A mapping of synthetic tokens to the exchange where they can be traded.
+export const TOKEN_TO_EXCHANGE_MAP: TokenExchangeMap = {
+  ycomp: EXCHANGES.UNISWAP,
+  ethbtc: EXCHANGES.UNISWAP,
+  yusd: EXCHANGES.BALANCER,
+};
+
+export const EXCHANGE_LINK_MAP: ExchangeLinkMap = {
+  [EXCHANGES.UNISWAP]: (tokenAddress) =>
+    `https://uniswap.info/token/${tokenAddress}`,
+  [EXCHANGES.BALANCER]: (tokenAddress) =>
+    `https://balancer.exchange/#/swap/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/${tokenAddress}`,
+};
+
+export const getExchangeTypeFromTokenSymbol = (symbol: string | null) => {
+  switch (true) {
+    case symbol?.includes("yCOMP"):
+      return TOKEN_TO_EXCHANGE_MAP.ycomp;
+    case symbol?.includes("ETHBTC"):
+      return TOKEN_TO_EXCHANGE_MAP.ethbtc;
+    case symbol?.includes("yUSD"):
+      return TOKEN_TO_EXCHANGE_MAP.yusd;
+    default:
+      return null;
+  }
+};
+
+export const getExchangeLinkFuncFromTokenSymbol = (symbol: string | null) => {
+  const exchangeType = getExchangeTypeFromTokenSymbol(symbol);
+  if (exchangeType !== null) {
+    return {
+      name: EXCHANGE_NAMES[exchangeType],
+      baseurl: EXCHANGE_LINK_MAP[exchangeType],
+    };
+  }
+};


### PR DESCRIPTION
Previously we hardcoded the uniswap base URL for an exchange link, this no longer works since yUSD is exchanged on Balancer.

This is potentially way too much work to achieve this functionality, but I created a module `getExchangeLinks` that provides a mapping function from `emp.tokenSymbol ==> getExchangeLink()` where `getExchangeLink()` is a function that takes in some input and returns a URL to the exchange where you can trade for the token symbol. In the future if our tokens trade on other exchanges like Matcha then we can build off of this module to easily add other types of exchanges.

Open to suggestions for a more succinct way of achieving this dynamism.
Signed-off-by: Nick Pai <npai.nyc@gmail.com>