### PR TITLE
Add column sorting and pagination to EMP sponsors table

### DIFF
--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -1,20 +1,20 @@
 import { createContainer } from "unstated-next";
 import { useState, useEffect } from "react";
-import { BigNumberish, utils } from "ethers";
+import { utils } from "ethers";
+const fromWei = utils.formatUnits;
 
 import EmpContract from "./EmpContract";
+import EmpState from "./EmpState";
+import Collateral from "./Collateral";
+import PriceFeed from "./PriceFeed";
+import { getLiquidationPrice } from "../utils/getLiquidationPrice";
 
 import { useQuery } from "@apollo/client";
 import { ACTIVE_POSITIONS } from "../apollo/uma/queries";
 
 // Interfaces for dApp state storage.
-interface PositionState {
-  tokensOutstanding: BigNumberish;
-  collateral: BigNumberish;
-}
-
-interface SponsorPositionState extends PositionState {
-  sponsor: string;
+interface SponsorPositionState {
+  [key: string]: string;
 }
 
 interface SponsorMap {
@@ -22,8 +22,10 @@ interface SponsorMap {
 }
 
 // Interfaces for GraphQl queries.
-interface PositionQuery extends PositionState {
+interface PositionQuery {
   sponsor: { id: string };
+  tokensOutstanding: string;
+  collateral: string;
 }
 
 interface FinancialContractQuery {
@@ -33,6 +35,11 @@ interface FinancialContractQuery {
 
 const useEmpSponsors = () => {
   const { contract: emp } = EmpContract.useContainer();
+  const { empState } = EmpState.useContainer();
+  const { collateralRequirement } = empState;
+  const { latestPrice } = PriceFeed.useContainer();
+  const { decimals: collDecs } = Collateral.useContainer();
+
   // Because apollo caches results of queries, we will poll/refresh this query periodically.
   // We set the poll interval to a very slow 5 seconds for now since the position states
   // are not expected to change much.
@@ -42,13 +49,29 @@ const useEmpSponsors = () => {
     pollInterval: 5000,
   });
 
+  const getCollateralRatio = (
+    collateral: number,
+    tokens: number,
+    price: number
+  ) => {
+    if (tokens <= 0 || price <= 0) return 0;
+    const tokensScaled = tokens * price;
+    return collateral / tokensScaled;
+  };
+
   const [activePositions, setActivePositions] = useState<SponsorMap>({});
 
   // get position information about every sponsor that has ever created a position.
   const querySponsors = () => {
     // Start with a fresh table.
-    let newPositions: SponsorMap = {};
-    if (emp) {
+    setActivePositions({});
+
+    if (
+      emp !== null &&
+      latestPrice !== null &&
+      collateralRequirement !== null &&
+      collDecs !== null
+    ) {
       if (error) {
         console.error(`Apollo client failed to fetch graph data:`, error);
       }
@@ -59,12 +82,31 @@ const useEmpSponsors = () => {
         );
 
         if (empData) {
+          let newPositions: SponsorMap = {};
+
+          const collReqFromWei = parseFloat(
+            fromWei(collateralRequirement, collDecs)
+          );
+
           empData.positions.forEach((position: PositionQuery) => {
             const sponsor = utils.getAddress(position.sponsor.id);
+
+            const cRatio = getCollateralRatio(
+              Number(position.collateral),
+              Number(position.tokensOutstanding),
+              latestPrice
+            );
+            const liquidationPrice = getLiquidationPrice(
+              Number(position.collateral),
+              Number(position.tokensOutstanding),
+              collReqFromWei
+            );
 
             newPositions[sponsor] = {
               tokensOutstanding: position.tokensOutstanding,
               collateral: position.collateral,
+              cRatio: cRatio.toString(),
+              liquidationPrice: liquidationPrice.toString(),
               sponsor,
             };
           });
@@ -78,7 +120,7 @@ const useEmpSponsors = () => {
   // Change state when emp changes or when the graphQL data changes due to polling.
   useEffect(() => {
     querySponsors();
-  }, [emp, data]);
+  }, [emp, data, latestPrice]);
 
   return { activeSponsors: activePositions };
 };

--- a/features/all-positions/AllPositions.tsx
+++ b/features/all-positions/AllPositions.tsx
@@ -45,7 +45,7 @@ const PageButtons = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 2em;
-  margin-bottom: 0.5em;
+  margin-bottom: 2em;
 `;
 
 type FadedDiv = {

--- a/features/all-positions/AllPositions.tsx
+++ b/features/all-positions/AllPositions.tsx
@@ -216,7 +216,9 @@ const AllPositions = () => {
                     placement="top"
                   >
                     <TableCell align="right">
-                      <SortableTableColumnHeader sortField={SORT_FIELD.CRATIO}>
+                      <SortableTableColumnHeader
+                        sortField={SORT_FIELD.LIQ_PRICE}
+                      >
                         Liquidation Price{" "}
                       </SortableTableColumnHeader>
                     </TableCell>

--- a/features/all-positions/AllPositions.tsx
+++ b/features/all-positions/AllPositions.tsx
@@ -21,6 +21,11 @@ import EmpSponsors from "../../containers/EmpSponsors";
 import PriceFeed from "../../containers/PriceFeed";
 import Etherscan from "../../containers/Etherscan";
 
+interface SortableTableHeaderProps {
+  children: React.ReactNode;
+  sortField: number;
+}
+
 const Link = styled.a`
   color: white;
   font-size: 18px;
@@ -152,6 +157,25 @@ const AllPositions = () => {
       })
       .slice(ITEMS_PER_PAGE * (page - 1), page * ITEMS_PER_PAGE);
 
+    const SortableTableColumnHeader = ({
+      children,
+      sortField,
+    }: SortableTableHeaderProps) => {
+      return (
+        <ClickableText
+          onClick={(e) => {
+            setSortedColumn(sortField);
+            setSortDirection(
+              sortedColumn !== sortField ? true : !sortDirection
+            );
+          }}
+        >
+          {children}
+          {sortedColumn === sortField ? (!sortDirection ? "↑" : "↓") : ""}
+        </ClickableText>
+      );
+    };
+
     return (
       <Box>
         <Box>
@@ -169,86 +193,32 @@ const AllPositions = () => {
                 <TableRow>
                   <TableCell>Sponsor</TableCell>
                   <TableCell align="right">
-                    <ClickableText
-                      onClick={(e) => {
-                        setSortedColumn(SORT_FIELD.COLLATERAL);
-                        setSortDirection(
-                          sortedColumn !== SORT_FIELD.COLLATERAL
-                            ? true
-                            : !sortDirection
-                        );
-                      }}
+                    <SortableTableColumnHeader
+                      sortField={SORT_FIELD.COLLATERAL}
                     >
                       Collateral
                       <br />({collSymbol}){" "}
-                      {sortedColumn === SORT_FIELD.COLLATERAL
-                        ? !sortDirection
-                          ? "↑"
-                          : "↓"
-                        : ""}
-                    </ClickableText>
+                    </SortableTableColumnHeader>
                   </TableCell>
                   <TableCell align="right">
-                    <ClickableText
-                      onClick={(e) => {
-                        setSortedColumn(SORT_FIELD.TOKENS);
-                        setSortDirection(
-                          sortedColumn !== SORT_FIELD.TOKENS
-                            ? true
-                            : !sortDirection
-                        );
-                      }}
-                    >
+                    <SortableTableColumnHeader sortField={SORT_FIELD.TOKENS}>
                       Synthetics
                       <br />({tokenSymbol}){" "}
-                      {sortedColumn === SORT_FIELD.TOKENS
-                        ? !sortDirection
-                          ? "↑"
-                          : "↓"
-                        : ""}
-                    </ClickableText>
+                    </SortableTableColumnHeader>
                   </TableCell>
                   <TableCell align="right">
-                    <ClickableText
-                      onClick={(e) => {
-                        setSortedColumn(SORT_FIELD.CRATIO);
-                        setSortDirection(
-                          sortedColumn !== SORT_FIELD.CRATIO
-                            ? true
-                            : !sortDirection
-                        );
-                      }}
-                    >
+                    <SortableTableColumnHeader sortField={SORT_FIELD.CRATIO}>
                       Collateral Ratio{" "}
-                      {sortedColumn === SORT_FIELD.CRATIO
-                        ? !sortDirection
-                          ? "↑"
-                          : "↓"
-                        : ""}
-                    </ClickableText>
+                    </SortableTableColumnHeader>
                   </TableCell>
                   <Tooltip
                     title={`This is the price that the identifier (${priceIdUtf8}) must increase to in order for the position be liquidatable`}
                     placement="top"
                   >
                     <TableCell align="right">
-                      <ClickableText
-                        onClick={(e) => {
-                          setSortedColumn(SORT_FIELD.LIQ_PRICE);
-                          setSortDirection(
-                            sortedColumn !== SORT_FIELD.LIQ_PRICE
-                              ? true
-                              : !sortDirection
-                          );
-                        }}
-                      >
+                      <SortableTableColumnHeader sortField={SORT_FIELD.CRATIO}>
                         Liquidation Price{" "}
-                        {sortedColumn === SORT_FIELD.LIQ_PRICE
-                          ? !sortDirection
-                            ? "↑"
-                            : "↓"
-                          : ""}
-                      </ClickableText>
+                      </SortableTableColumnHeader>
                     </TableCell>
                   </Tooltip>
                 </TableRow>

--- a/features/all-positions/AllPositions.tsx
+++ b/features/all-positions/AllPositions.tsx
@@ -104,6 +104,7 @@ const AllPositions = () => {
         Math.floor(Object.keys(activeSponsors).length / ITEMS_PER_PAGE) +
           extraPages
       );
+      // This will set maxPage to 0 if there are no sponsors.
     }
   }, [activeSponsors]);
 
@@ -127,176 +128,189 @@ const AllPositions = () => {
 
     return (
       <Box>
-        <Box>
-          <Typography>
-            {`Estimated price of ${latestPrice} for ${priceIdUtf8} sourced from: `}
-            <Link href={sourceUrl} target="_blank" rel="noopener noreferrer">
-              Coinbase Pro.
-            </Link>
-          </Typography>
-        </Box>
-        <Box pt={4}>
-          {activeSponsors && (
-            <TableContainer component={Paper}>
-              <Table>
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Sponsor</TableCell>
-                    <TableCell align="right">
-                      <ClickableText
-                        onClick={(e) => {
-                          setSortedColumn(SORT_FIELD.COLLATERAL);
-                          setSortDirection(
-                            sortedColumn !== SORT_FIELD.COLLATERAL
-                              ? true
-                              : !sortDirection
-                          );
-                        }}
-                      >
-                        Collateral
-                        <br />({collSymbol}){" "}
-                        {sortedColumn === SORT_FIELD.COLLATERAL
-                          ? !sortDirection
-                            ? "↑"
-                            : "↓"
-                          : ""}
-                      </ClickableText>
-                    </TableCell>
-                    <TableCell align="right">
-                      <ClickableText
-                        onClick={(e) => {
-                          setSortedColumn(SORT_FIELD.TOKENS);
-                          setSortDirection(
-                            sortedColumn !== SORT_FIELD.TOKENS
-                              ? true
-                              : !sortDirection
-                          );
-                        }}
-                      >
-                        Synthetics
-                        <br />({tokenSymbol}){" "}
-                        {sortedColumn === SORT_FIELD.TOKENS
-                          ? !sortDirection
-                            ? "↑"
-                            : "↓"
-                          : ""}
-                      </ClickableText>
-                    </TableCell>
-                    <TableCell align="right">
-                      <ClickableText
-                        onClick={(e) => {
-                          setSortedColumn(SORT_FIELD.CRATIO);
-                          setSortDirection(
-                            sortedColumn !== SORT_FIELD.CRATIO
-                              ? true
-                              : !sortDirection
-                          );
-                        }}
-                      >
-                        Collateral Ratio{" "}
-                        {sortedColumn === SORT_FIELD.CRATIO
-                          ? !sortDirection
-                            ? "↑"
-                            : "↓"
-                          : ""}
-                      </ClickableText>
-                    </TableCell>
-                    <Tooltip
-                      title={`This is the price that the identifier (${priceIdUtf8}) must increase to in order for the position be liquidatable`}
-                      placement="top"
-                    >
+        {activeSponsors && Object.keys(activeSponsors).length > 0 && (
+          <>
+            <Box>
+              <Typography>
+                {`Estimated price of ${latestPrice} for ${priceIdUtf8} sourced from: `}
+                <Link
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Coinbase Pro.
+                </Link>
+              </Typography>
+            </Box>
+            <Box pt={4}>
+              <TableContainer component={Paper}>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Sponsor</TableCell>
                       <TableCell align="right">
                         <ClickableText
                           onClick={(e) => {
-                            setSortedColumn(SORT_FIELD.LIQ_PRICE);
+                            setSortedColumn(SORT_FIELD.COLLATERAL);
                             setSortDirection(
-                              sortedColumn !== SORT_FIELD.LIQ_PRICE
+                              sortedColumn !== SORT_FIELD.COLLATERAL
                                 ? true
                                 : !sortDirection
                             );
                           }}
                         >
-                          Liquidation Price{" "}
-                          {sortedColumn === SORT_FIELD.LIQ_PRICE
+                          Collateral
+                          <br />({collSymbol}){" "}
+                          {sortedColumn === SORT_FIELD.COLLATERAL
                             ? !sortDirection
                               ? "↑"
                               : "↓"
                             : ""}
                         </ClickableText>
                       </TableCell>
-                    </Tooltip>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {Object.keys(activeSponsors)
-                    .filter((sponsor: string) => {
-                      return (
-                        activeSponsors[sponsor]?.collateral &&
-                        activeSponsors[sponsor]?.tokensOutstanding &&
-                        activeSponsors[sponsor]?.cRatio &&
-                        activeSponsors[sponsor]?.liquidationPrice
-                      );
-                    })
-                    .sort((sponsorA: string, sponsorB: string) => {
-                      const fieldValueA =
-                        activeSponsors[sponsorA][FIELD_TO_VALUE[sortedColumn]];
-                      const fieldValueB =
-                        activeSponsors[sponsorB][FIELD_TO_VALUE[sortedColumn]];
-                      return Number(fieldValueA) > Number(fieldValueB)
-                        ? (sortDirection ? -1 : 1) * 1
-                        : (sortDirection ? -1 : 1) * -1;
-                    })
-                    .slice(ITEMS_PER_PAGE * (page - 1), page * ITEMS_PER_PAGE)
-                    .map((sponsor: string) => {
-                      const activeSponsor = activeSponsors[sponsor];
-                      return (
-                        <TableRow key={sponsor}>
-                          <TableCell component="th" scope="row">
-                            <a href={getEtherscanUrl(sponsor)} target="_blank">
-                              {prettyAddress(sponsor)}
-                            </a>
-                          </TableCell>
-                          <TableCell align="right">
-                            {prettyBalance(Number(activeSponsor.collateral))}
-                          </TableCell>
-                          <TableCell align="right">
-                            {prettyBalance(
-                              Number(activeSponsor.tokensOutstanding)
-                            )}
-                          </TableCell>
-                          <TableCell align="right">
-                            {prettyBalance(Number(activeSponsor.cRatio))}
-                          </TableCell>
-                          <TableCell align="right">
-                            {prettyBalance(
-                              Number(activeSponsor.liquidationPrice)
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                </TableBody>
-              </Table>
-              <PageButtons>
-                <div
-                  onClick={(e) => {
-                    setPage(page === 1 ? page : page - 1);
-                  }}
-                >
-                  <Arrow faded={page === 1 ? true : false}>←</Arrow>
-                </div>
-                {"Page " + page + " of " + maxPage}
-                <div
-                  onClick={(e) => {
-                    setPage(page === maxPage ? page : page + 1);
-                  }}
-                >
-                  <Arrow faded={page === maxPage ? true : false}>→</Arrow>
-                </div>
-              </PageButtons>
-            </TableContainer>
-          )}
-        </Box>
+                      <TableCell align="right">
+                        <ClickableText
+                          onClick={(e) => {
+                            setSortedColumn(SORT_FIELD.TOKENS);
+                            setSortDirection(
+                              sortedColumn !== SORT_FIELD.TOKENS
+                                ? true
+                                : !sortDirection
+                            );
+                          }}
+                        >
+                          Synthetics
+                          <br />({tokenSymbol}){" "}
+                          {sortedColumn === SORT_FIELD.TOKENS
+                            ? !sortDirection
+                              ? "↑"
+                              : "↓"
+                            : ""}
+                        </ClickableText>
+                      </TableCell>
+                      <TableCell align="right">
+                        <ClickableText
+                          onClick={(e) => {
+                            setSortedColumn(SORT_FIELD.CRATIO);
+                            setSortDirection(
+                              sortedColumn !== SORT_FIELD.CRATIO
+                                ? true
+                                : !sortDirection
+                            );
+                          }}
+                        >
+                          Collateral Ratio{" "}
+                          {sortedColumn === SORT_FIELD.CRATIO
+                            ? !sortDirection
+                              ? "↑"
+                              : "↓"
+                            : ""}
+                        </ClickableText>
+                      </TableCell>
+                      <Tooltip
+                        title={`This is the price that the identifier (${priceIdUtf8}) must increase to in order for the position be liquidatable`}
+                        placement="top"
+                      >
+                        <TableCell align="right">
+                          <ClickableText
+                            onClick={(e) => {
+                              setSortedColumn(SORT_FIELD.LIQ_PRICE);
+                              setSortDirection(
+                                sortedColumn !== SORT_FIELD.LIQ_PRICE
+                                  ? true
+                                  : !sortDirection
+                              );
+                            }}
+                          >
+                            Liquidation Price{" "}
+                            {sortedColumn === SORT_FIELD.LIQ_PRICE
+                              ? !sortDirection
+                                ? "↑"
+                                : "↓"
+                              : ""}
+                          </ClickableText>
+                        </TableCell>
+                      </Tooltip>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {Object.keys(activeSponsors)
+                      .filter((sponsor: string) => {
+                        return (
+                          activeSponsors[sponsor]?.collateral &&
+                          activeSponsors[sponsor]?.tokensOutstanding &&
+                          activeSponsors[sponsor]?.cRatio &&
+                          activeSponsors[sponsor]?.liquidationPrice
+                        );
+                      })
+                      .sort((sponsorA: string, sponsorB: string) => {
+                        const fieldValueA =
+                          activeSponsors[sponsorA][
+                            FIELD_TO_VALUE[sortedColumn]
+                          ];
+                        const fieldValueB =
+                          activeSponsors[sponsorB][
+                            FIELD_TO_VALUE[sortedColumn]
+                          ];
+                        return Number(fieldValueA) > Number(fieldValueB)
+                          ? (sortDirection ? -1 : 1) * 1
+                          : (sortDirection ? -1 : 1) * -1;
+                      })
+                      .slice(ITEMS_PER_PAGE * (page - 1), page * ITEMS_PER_PAGE)
+                      .map((sponsor: string) => {
+                        const activeSponsor = activeSponsors[sponsor];
+                        return (
+                          <TableRow key={sponsor}>
+                            <TableCell component="th" scope="row">
+                              <a
+                                href={getEtherscanUrl(sponsor)}
+                                target="_blank"
+                              >
+                                {prettyAddress(sponsor)}
+                              </a>
+                            </TableCell>
+                            <TableCell align="right">
+                              {prettyBalance(Number(activeSponsor.collateral))}
+                            </TableCell>
+                            <TableCell align="right">
+                              {prettyBalance(
+                                Number(activeSponsor.tokensOutstanding)
+                              )}
+                            </TableCell>
+                            <TableCell align="right">
+                              {prettyBalance(Number(activeSponsor.cRatio))}
+                            </TableCell>
+                            <TableCell align="right">
+                              {prettyBalance(
+                                Number(activeSponsor.liquidationPrice)
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                  </TableBody>
+                </Table>
+                <PageButtons>
+                  <div
+                    onClick={() => {
+                      setPage(page === 1 ? page : page - 1);
+                    }}
+                  >
+                    <Arrow faded={page === 1 ? true : false}>←</Arrow>
+                  </div>
+                  {"Page " + page + " of " + maxPage}
+                  <div
+                    onClick={() => {
+                      setPage(page === maxPage ? page : page + 1);
+                    }}
+                  >
+                    <Arrow faded={page === maxPage ? true : false}>→</Arrow>
+                  </div>
+                </PageButtons>
+              </TableContainer>
+            </Box>
+          </>
+        )}
       </Box>
     );
   } else {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,21 +32,21 @@ const WithStateContainerProviders = ({ children }: IProps) => (
         <EmpContract.Provider>
           <WethContract.Provider>
             <EmpState.Provider>
-              <EmpSponsors.Provider>
+              <Token.Provider>
                 <Collateral.Provider>
-                  <Token.Provider>
-                    <Totals.Provider>
-                      <PriceFeed.Provider>
+                  <PriceFeed.Provider>
+                    <EmpSponsors.Provider>
+                      <Totals.Provider>
                         <Etherscan.Provider>
                           <Position.Provider>
                             <Balancer.Provider>{children}</Balancer.Provider>
                           </Position.Provider>
                         </Etherscan.Provider>
-                      </PriceFeed.Provider>
-                    </Totals.Provider>
-                  </Token.Provider>
+                      </Totals.Provider>
+                    </EmpSponsors.Provider>
+                  </PriceFeed.Provider>
                 </Collateral.Provider>
-              </EmpSponsors.Provider>
+              </Token.Provider>
             </EmpState.Provider>
           </WethContract.Provider>
         </EmpContract.Provider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,7 +75,7 @@ export default function Index() {
         <Hidden only={["sm", "xs"]}>
           <StyledTabs value={tabIndex} onChange={(_, i) => setTabIndex(i)}>
             {options.map((option, index) => (
-              <Tab label={option} disableRipple />
+              <Tab key={option} label={option} disableRipple />
             ))}
           </StyledTabs>
         </Hidden>


### PR DESCRIPTION
Resolves #84  
Resolves #83 

I also moved `cRatio` and `liquidationPrice` to the EMPSponsors.ts container instead of calculating it in the AllPositions.tsx component.

Attribution: heavily inspired by [uniswap.info's](https://github.com/Uniswap/uniswap-info/blob/v2/src/components/PairList/index.js) [pagination](https://uniswap.info/home)!