### PR TITLE
Increase query count + add shareholder data

### DIFF
--- a/apollo/balancer/queries.ts
+++ b/apollo/balancer/queries.ts
@@ -23,6 +23,11 @@ export const POOL = (stringifiedTokenList: String) => gql`
       joinsCount
       exitsCount
       swapsCount
+      shares(first:1000) {
+        userAddress {
+          id
+        }
+      }
     }
   }
 `;

--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -4,7 +4,7 @@ export const ACTIVE_POSITIONS = gql`
   query activePositions {
     financialContracts {
       id
-      positions(where: { collateral_gt: 0 }) {
+      positions(first: 1000, where: { collateral_gt: 0 }) {
         collateral
         tokensOutstanding
         sponsor {

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -15,7 +15,16 @@ interface PoolState {
   totalSwapVolume: number;
 }
 
-interface PoolTokenState {
+interface SharesState {
+  [address: string]: string;
+}
+
+interface SharesQuery {
+  [address: string]: {
+    id: string;
+  };
+}
+interface PoolTokenQuery {
   address: string;
   balance: string;
 }
@@ -51,6 +60,7 @@ const useBalancer = () => {
   const [usdPrice, setUsdPrice] = useState<number | null>(null);
   const [poolAddress, setPoolAddress] = useState<string | null>(null);
   const [pool, setPool] = useState<PoolState | null>(null);
+  const [shares, setShares] = useState<SharesState | null>(null);
 
   const queryTokenData = () => {
     setUsdPrice(null);
@@ -73,12 +83,22 @@ const useBalancer = () => {
 
   const queryPoolData = () => {
     setPool(null);
+    setShares(null);
 
     if (poolError) {
       console.error(`Apollo client failed to fetch graph data:`, poolError);
     }
     if (!poolLoading && poolData) {
       const data = poolData.pools[0];
+
+      const shareHolders: SharesState = {};
+      data.shares.forEach((share: SharesQuery) => {
+        if (!shareHolders[share.userAddress.id]) {
+          shareHolders[share.userAddress.id] = share.userAddress.id;
+        }
+      });
+      setShares(shareHolders);
+
       setPool({
         exitsCount: Number(data.exitsCount),
         joinsCount: Number(data.joinsCount),
@@ -86,11 +106,11 @@ const useBalancer = () => {
         liquidity: Number(data.liquidity),
         swapFee: Number(data.swapFee),
         tokenBalanceEmp: Number(
-          data.tokens.find((t: PoolTokenState) => t.address === empAddress)
+          data.tokens.find((t: PoolTokenQuery) => t.address === empAddress)
             .balance
         ),
         tokenBalanceOther: Number(
-          data.tokens.find((t: PoolTokenState) => t.address === usdcAddress)
+          data.tokens.find((t: PoolTokenQuery) => t.address === usdcAddress)
             .balance
         ),
         totalSwapVolume: Number(data.totalSwapVolume),
@@ -108,6 +128,7 @@ const useBalancer = () => {
     pool,
     poolAddress,
     usdPrice,
+    shares,
   };
 };
 

--- a/features/yield/BalancerData.tsx
+++ b/features/yield/BalancerData.tsx
@@ -18,9 +18,14 @@ const Link = styled.a`
 `;
 
 const BalancerData = () => {
-  const { poolAddress, usdPrice, pool } = Balancer.useContainer();
+  const { poolAddress, usdPrice, pool, shares } = Balancer.useContainer();
 
-  if (poolAddress !== null && usdPrice !== null && pool !== null) {
+  if (
+    poolAddress !== null &&
+    usdPrice !== null &&
+    pool !== null &&
+    shares !== null
+  ) {
     const balancerPoolUrl = `https://pools.balancer.exchange/#/pool/${poolAddress}`;
     return renderComponent(
       balancerPoolUrl,
@@ -32,7 +37,8 @@ const BalancerData = () => {
       `${pool.swapFee}%`,
       `${pool.swapsCount}`,
       `${pool.exitsCount}`,
-      `${pool.joinsCount}`
+      `${pool.joinsCount}`,
+      `${Object.keys(shares).length}`
     );
   } else {
     return renderComponent();
@@ -48,7 +54,8 @@ const BalancerData = () => {
     poolSwapFee: string = "",
     poolSwapCount: string = "",
     poolExitsCount: string = "",
-    poolJoinsCount: string = ""
+    poolJoinsCount: string = "",
+    uniqueShareholders: string = ""
   ) {
     return (
       <span>
@@ -106,6 +113,12 @@ const BalancerData = () => {
             <Status>
               <Label>Exits count: </Label>
               {poolExitsCount}
+            </Status>
+          </Grid>
+          <Grid item md={6} sm={6} xs={12}>
+            <Status>
+              <Label>Unique LPs: </Label>
+              {uniqueShareholders}
             </Status>
           </Grid>
         </Grid>


### PR DESCRIPTION
- By default, the UMA subgraph returns 100 positions for the `positions` query but we have > 140 so I set this to the max 1000 (follow up PR will have to figure out how pagination works for the subgraph)
- Add `shares` query to Balancer data to see number of unique contributors. Also only allowed to query up to 1000

Signed-off-by: Nick Pai <npai.nyc@gmail.com>