### PR TITLE
implemented eip747

### DIFF
--- a/containers/Connection.ts
+++ b/containers/Connection.ts
@@ -34,6 +34,7 @@ function useConnection() {
     );
     const signer = provider.getSigner();
     const network = await provider.getNetwork();
+
     // get address
     await provider.send("eth_requestAccounts", []);
     const address = await signer.getAddress();

--- a/containers/Connection.ts
+++ b/containers/Connection.ts
@@ -34,7 +34,6 @@ function useConnection() {
     );
     const signer = provider.getSigner();
     const network = await provider.getNetwork();
-
     // get address
     await provider.send("eth_requestAccounts", []);
     const address = await signer.getAddress();

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
-import { Box, Grid, Typography } from "@material-ui/core";
+import { Box, Grid, Typography, Button } from "@material-ui/core";
 
 import TotalsContainer from "../../containers/Totals";
 import Collateral from "../../containers/Collateral";
 import Token from "../../containers/Token";
 import Etherscan from "../../containers/Etherscan";
 
+import Connection from "../../containers/Connection";
 import { getExchangeInfo } from "../../utils/getExchangeLinks";
 
 const DataBox = styled(Box)`
@@ -42,6 +43,7 @@ const White = styled.span`
 `;
 
 const Totals = () => {
+  const { provider } = Connection.useContainer();
   const { totalCollateral, totalTokens } = TotalsContainer.useContainer();
   const {
     symbol: collSymbol,
@@ -87,10 +89,29 @@ const Totals = () => {
     prettyTotalTokens: string = defaultMissingDataDisplay,
     prettyCollSymbol: string = "",
     prettyTokenSymbol: string = "",
-    getExchangeLinkCollateral: string = "https://app.uniswap.org/#/swap",
-    getExchangeLinkToken: string = "https://app.uniswap.org/#/swap",
+    getExchangeLinkCollateral: string = "",
+    getExchangeLinkToken: string = "",
     exchangeName: string = "Uniswap"
   ) {
+    const addTokenToMetamask = async () => {
+      // Add token to users metamask wallet.
+      if (provider == null) return;
+
+      // @ts-ignore
+      provider.send("wallet_watchAsset", {
+        // @ts-ignore
+        type: "ERC20",
+        options: {
+          address: tokenAddress,
+          symbol: tokenSymbol?.substring(0, 6),
+          name: "test",
+          decimals: 18,
+          image:
+            "https://etherscan.io/token/images/yusdsynthetictokenexpiring1september2020_32.png",
+        },
+        id: Math.round(Math.random() * 100000),
+      });
+    };
     return (
       <>
         <Grid item md={6} xs={12}>
@@ -103,20 +124,24 @@ const Totals = () => {
               of <White>collateral</White> supplied
             </Label>
             <LinksContainer>
-              <SmallLink
-                href={getEtherscanUrl(collAddress)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Etherscan
-              </SmallLink>
-              <SmallLink
-                href={getExchangeLinkCollateral}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {exchangeName}
-              </SmallLink>
+              {collAddress && (
+                <SmallLink
+                  href={getEtherscanUrl(collAddress)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Etherscan
+                </SmallLink>
+              )}
+              {getExchangeLinkCollateral != "" && (
+                <SmallLink
+                  href={getExchangeLinkCollateral}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {exchangeName}
+                </SmallLink>
+              )}
             </LinksContainer>
           </DataBox>
         </Grid>
@@ -131,20 +156,31 @@ const Totals = () => {
               of <White>synthetic tokens</White> outstanding
             </Label>
             <LinksContainer>
-              <SmallLink
-                href={getEtherscanUrl(tokenAddress)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Etherscan
-              </SmallLink>
-              <SmallLink
-                href={getExchangeLinkToken}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {exchangeName}
-              </SmallLink>
+              {tokenAddress && (
+                <SmallLink
+                  href={getEtherscanUrl(tokenAddress)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Etherscan
+                </SmallLink>
+              )}
+
+              {getExchangeLinkToken != "" && (
+                <SmallLink
+                  href={getExchangeLinkToken}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {exchangeName}
+                </SmallLink>
+              )}
+
+              {tokenAddress && (
+                <SmallLink href="#" onClick={addTokenToMetamask}>
+                  Add to Metamask
+                </SmallLink>
+              )}
             </LinksContainer>
           </DataBox>
         </Grid>

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -73,9 +73,6 @@ const Totals = () => {
     const exchangeName = exchangeInfo.name;
 
     const addTokenToMetamask = () => {
-      // Add token to users metamask wallet.
-      if (provider == null) return;
-
       // @ts-ignore
       provider.send("wallet_watchAsset", {
         // @ts-ignore
@@ -184,7 +181,7 @@ const Totals = () => {
                 </SmallLink>
               )}
 
-              {tokenAddress !== "" && (
+              {tokenAddress !== "" && tokenSymbol === "yUSD-SEP20" && (
                 <SmallLink href="#" onClick={addTokenToMetamask}>
                   Add to Metamask
                 </SmallLink>

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -82,11 +82,11 @@ const Totals = () => {
         type: "ERC20",
         options: {
           address: tokenAddress,
-          symbol: tokenSymbol.substring(0, 6),
+          symbol: tokenSymbol.substring(0, 4),
           name: "test",
           decimals: 18,
           image:
-            "https://etherscan.io/token/images/yusdsynthetictokenexpiring1september2020_32.png",
+            "https://raw.githubusercontent.com/UMAprotocol/website/master/src/assets/images/yusd-round.png",
         },
         id: Math.round(Math.random() * 100000),
       });

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -61,7 +61,8 @@ const Totals = () => {
     tokenSymbol !== null &&
     exchangeInfo !== undefined &&
     collAddress !== null &&
-    tokenAddress !== null
+    tokenAddress !== null &&
+    provider !== null
   ) {
     const prettyTotalCollateral = Number(totalCollateral).toLocaleString();
     const prettyTotalTokens = Number(totalTokens).toLocaleString();
@@ -71,29 +72,7 @@ const Totals = () => {
     const getExchangeLinkToken = exchangeInfo.getExchangeUrl(tokenAddress);
     const exchangeName = exchangeInfo.name;
 
-    return renderComponent(
-      prettyTotalCollateral,
-      prettyTotalTokens,
-      prettyCollSymbol,
-      prettyTokenSymbol,
-      getExchangeLinkCollateral,
-      getExchangeLinkToken,
-      exchangeName
-    );
-  } else {
-    return renderComponent();
-  }
-
-  function renderComponent(
-    prettyTotalCollateral: string = defaultMissingDataDisplay,
-    prettyTotalTokens: string = defaultMissingDataDisplay,
-    prettyCollSymbol: string = "",
-    prettyTokenSymbol: string = "",
-    getExchangeLinkCollateral: string = "",
-    getExchangeLinkToken: string = "",
-    exchangeName: string = "Uniswap"
-  ) {
-    const addTokenToMetamask = async () => {
+    const addTokenToMetamask = () => {
       // Add token to users metamask wallet.
       if (provider == null) return;
 
@@ -112,6 +91,35 @@ const Totals = () => {
         id: Math.round(Math.random() * 100000),
       });
     };
+
+    return renderComponent(
+      prettyTotalCollateral,
+      prettyTotalTokens,
+      prettyCollSymbol,
+      prettyTokenSymbol,
+      collAddress,
+      tokenAddress,
+      getExchangeLinkCollateral,
+      getExchangeLinkToken,
+      exchangeName,
+      addTokenToMetamask
+    );
+  } else {
+    return renderComponent();
+  }
+
+  function renderComponent(
+    prettyTotalCollateral: string = defaultMissingDataDisplay,
+    prettyTotalTokens: string = defaultMissingDataDisplay,
+    prettyCollSymbol: string = "",
+    prettyTokenSymbol: string = "",
+    collAddress: string = "",
+    tokenAddress: string = "",
+    getExchangeLinkCollateral: string = "",
+    getExchangeLinkToken: string = "",
+    exchangeName: string = "Uniswap",
+    addTokenToMetamask: any = null
+  ) {
     return (
       <>
         <Grid item md={6} xs={12}>
@@ -124,7 +132,7 @@ const Totals = () => {
               of <White>collateral</White> supplied
             </Label>
             <LinksContainer>
-              {collAddress && (
+              {collAddress !== "" && (
                 <SmallLink
                   href={getEtherscanUrl(collAddress)}
                   target="_blank"
@@ -133,7 +141,7 @@ const Totals = () => {
                   Etherscan
                 </SmallLink>
               )}
-              {getExchangeLinkCollateral != "" && (
+              {getExchangeLinkCollateral !== "" && (
                 <SmallLink
                   href={getExchangeLinkCollateral}
                   target="_blank"
@@ -156,7 +164,7 @@ const Totals = () => {
               of <White>synthetic tokens</White> outstanding
             </Label>
             <LinksContainer>
-              {tokenAddress && (
+              {tokenAddress !== "" && (
                 <SmallLink
                   href={getEtherscanUrl(tokenAddress)}
                   target="_blank"
@@ -166,7 +174,7 @@ const Totals = () => {
                 </SmallLink>
               )}
 
-              {getExchangeLinkToken != "" && (
+              {getExchangeLinkToken !== "" && (
                 <SmallLink
                   href={getExchangeLinkToken}
                   target="_blank"
@@ -176,7 +184,7 @@ const Totals = () => {
                 </SmallLink>
               )}
 
-              {tokenAddress && (
+              {tokenAddress !== "" && (
                 <SmallLink href="#" onClick={addTokenToMetamask}>
                   Add to Metamask
                 </SmallLink>

--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -82,7 +82,7 @@ const Totals = () => {
         type: "ERC20",
         options: {
           address: tokenAddress,
-          symbol: tokenSymbol?.substring(0, 6),
+          symbol: tokenSymbol.substring(0, 6),
           name: "test",
           decimals: 18,
           image:


### PR DESCRIPTION
This PR adds a simple button to add the synthetic token to your metamask wallet. Additionally, this PR hides etherscan & market links until the user has selected a contract from the dropdown list.
![image](https://user-images.githubusercontent.com/12886084/88815688-e76d2200-d1bb-11ea-9a93-63145102176d.png)

![image](https://user-images.githubusercontent.com/12886084/88815695-e89e4f00-d1bb-11ea-9126-5bf9d4809e2d.png)

Open question: do we want this functionality? main issue is the token is limited to 6 chars in eip747. This is pretty painful as we loose token information (see screenshot).