### PR TITLE
SettleExpired Feature

### DIFF
--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -14,16 +14,3 @@ export const ACTIVE_POSITIONS = gql`
     }
   }
 `;
-
-export const PRICE_REQUESTS = gql`
-  query priceRequests {
-    priceRequests {
-      price
-      isResolved
-      time
-      identifier {
-        id
-      }
-    }
-  }
-`;

--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -14,3 +14,16 @@ export const ACTIVE_POSITIONS = gql`
     }
   }
 `;
+
+export const PRICE_REQUESTS = gql`
+  query priceRequests {
+    priceRequests {
+      price
+      isResolved
+      time
+      identifier {
+        id
+      }
+    }
+  }
+`;

--- a/containers/DvmContract.ts
+++ b/containers/DvmContract.ts
@@ -1,0 +1,38 @@
+import { createContainer } from "unstated-next";
+import { useState, useEffect } from "react";
+import { ethers } from "ethers";
+import uma from "@studydefi/money-legos/uma";
+
+import EmpState from "./EmpState";
+import Connection from "./Connection";
+
+const { formatBytes32String: utf8ToHex } = ethers.utils;
+
+function useContract() {
+  const { signer } = Connection.useContainer();
+  const { empState } = EmpState.useContainer();
+  const { finderAddress } = empState;
+  const [contract, setContract] = useState<ethers.Contract | null>(null);
+
+  const setDvmContract = async () => {
+    if (finderAddress !== null && signer !== null) {
+      const finder = new ethers.Contract(finderAddress, uma.finder.abi, signer);
+      const dvmAddress = await finder.getImplementationAddress(
+        utf8ToHex("Oracle")
+      );
+      const dvm = new ethers.Contract(dvmAddress, uma.voting.abi, signer);
+      setContract(dvm);
+    }
+  };
+  useEffect(() => {
+    setContract(null);
+
+    setDvmContract();
+  }, [finderAddress, signer]);
+
+  return { contract };
+}
+
+const Contract = createContainer(useContract);
+
+export default Contract;

--- a/containers/DvmContract.ts
+++ b/containers/DvmContract.ts
@@ -33,8 +33,6 @@ function useContract() {
     }
   };
   useEffect(() => {
-    setContract(null);
-
     setDvmContract();
   }, [finderAddress, provider]);
 

--- a/containers/DvmState.ts
+++ b/containers/DvmState.ts
@@ -1,0 +1,102 @@
+import { createContainer } from "unstated-next";
+import { useState, useEffect } from "react";
+import { utils } from "ethers";
+
+import Connection from "./Connection";
+import DvmContract from "./DvmContract";
+import EmpState from "./EmpState";
+
+const { formatUnits: fromWei } = utils;
+
+interface ContractState {
+  hasEmpPrice: boolean | null;
+  resolvedPrice: number | null;
+}
+
+const initState = {
+  hasEmpPrice: null,
+  resolvedPrice: null,
+};
+
+// Taken from Voting.sol implementation.
+enum PRICE_REQUEST_STATUSES {
+  NOT_REQUESTED, // Was never requested.
+  ACTIVE, // Is being voted on in the current round.
+  RESOLVED, // Was resolved in a previous round.
+  FUTURE, // Is scheduled to be voted on in a future round.
+}
+
+const useContractState = () => {
+  const { block$ } = Connection.useContainer();
+  const { contract: dvm } = DvmContract.useContainer();
+  const { empState } = EmpState.useContainer();
+  const { priceIdentifier, expirationTimestamp } = empState;
+
+  const [state, setState] = useState<ContractState>(initState);
+
+  // get state from EMP
+  const queryState = async () => {
+    if (
+      dvm !== null &&
+      priceIdentifier !== null &&
+      expirationTimestamp !== null
+    ) {
+      const res = await Promise.all([
+        dvm.getPriceRequestStatuses([
+          {
+            identifier: priceIdentifier.toString(),
+            time: expirationTimestamp.toNumber(),
+          },
+        ]),
+      ]);
+
+      const hasPrice = res[0][0].status === PRICE_REQUEST_STATUSES.RESOLVED;
+
+      let resolvedPrice = null;
+      if (hasPrice) {
+        try {
+          const postResolutionRes = await Promise.all([
+            // `getPrice()` will fail on mainnet because the deployed `Voting.getPrice()` is required to be called from a registered contract, such as this EMP!
+            // TODO: Figure out a way to spoof the `from` parameter in this contract call and set to `emp.address`. One possibility is via the UMA subgraph
+            dvm.getPrice(
+              priceIdentifier.toString(),
+              expirationTimestamp.toNumber()
+            ),
+          ]);
+
+          resolvedPrice = parseFloat(fromWei(postResolutionRes.toString()));
+        } catch (err) {
+          console.error(`getPrice failed:`, err);
+        }
+      }
+
+      const newState: ContractState = {
+        hasEmpPrice: hasPrice,
+        resolvedPrice: resolvedPrice,
+      };
+
+      setState(newState);
+    }
+  };
+
+  // get state on setting of contract
+  useEffect(() => {
+    setState(initState);
+
+    queryState();
+  }, [dvm, priceIdentifier, expirationTimestamp]);
+
+  // get state on each block
+  useEffect(() => {
+    if (block$ && dvm) {
+      const sub = block$.subscribe(() => queryState());
+      return () => sub.unsubscribe();
+    }
+  }, [block$, dvm]);
+
+  return { dvmState: state };
+};
+
+const DvmState = createContainer(useContractState);
+
+export default DvmState;

--- a/containers/DvmState.ts
+++ b/containers/DvmState.ts
@@ -2,14 +2,12 @@ import { createContainer } from "unstated-next";
 import { useState, useEffect } from "react";
 import { utils } from "ethers";
 
-import { useQuery } from "@apollo/client";
-import { PRICE_REQUESTS } from "../apollo/uma/queries";
-
 import Connection from "./Connection";
 import DvmContract from "./DvmContract";
 import EmpState from "./EmpState";
+import EmpAddress from "./EmpAddress";
 
-const { formatUnits: fromWei, parseBytes32String: hexToUtf8 } = utils;
+const { formatUnits: fromWei } = utils;
 
 interface ContractState {
   hasEmpPrice: boolean | null;
@@ -29,29 +27,14 @@ enum PRICE_REQUEST_STATUSES {
   FUTURE, // Is scheduled to be voted on in a future round.
 }
 
-interface PriceRequestQuery {
-  identifier: {
-    id: string;
-  };
-  time: string;
-}
-
 const useContractState = () => {
   const { block$ } = Connection.useContainer();
   const { contract: dvm } = DvmContract.useContainer();
   const { empState } = EmpState.useContainer();
   const { priceIdentifier, expirationTimestamp } = empState;
+  const { empAddress } = EmpAddress.useContainer();
 
   const [state, setState] = useState<ContractState>(initState);
-
-  // Because apollo caches results of queries, we will poll/refresh this query periodically.
-  // We set the poll interval to a very slow 5 seconds for now since the position states
-  // are not expected to change much.
-  // Source: https://www.apollographql.com/docs/react/data/queries/#polling
-  const { loading, error, data } = useQuery(PRICE_REQUESTS, {
-    context: { clientName: "UMA" },
-    pollInterval: 5000,
-  });
 
   // get state from EMP
   const queryState = async () => {
@@ -61,51 +44,29 @@ const useContractState = () => {
       expirationTimestamp !== null
     ) {
       const res = await Promise.all([
-        dvm.getPriceRequestStatuses([
-          {
-            identifier: priceIdentifier.toString(),
-            time: expirationTimestamp.toNumber(),
-          },
-        ]),
+        dvm.hasPrice(
+          priceIdentifier.toString(),
+          expirationTimestamp.toNumber(),
+          { from: empAddress }
+        ),
       ]);
 
-      const hasPrice = res[0][0].status === PRICE_REQUEST_STATUSES.RESOLVED;
+      const hasPrice = res[0] as boolean;
 
       let resolvedPrice = null;
-
-      // Fetch price from graph if available.
-      if (error) {
-        console.error(`Apollo client failed to fetch graph data:`, error);
-      } else if (hasPrice && !loading && data) {
-        // Implementation 1: Use subgraph data. This works for mainnet but not Kovan since the UMA subgraph does not currently index Kovan data.
-        const matchingPriceRequest = data.priceRequests.find(
-          (request: PriceRequestQuery) => {
-            return (
-              request.identifier.id === hexToUtf8(priceIdentifier) &&
-              request.time === expirationTimestamp.toString()
-            );
-          }
-        );
-        if (matchingPriceRequest && matchingPriceRequest.isResolved) {
-          resolvedPrice = parseFloat(
-            fromWei(matchingPriceRequest.price.toString())
-          );
+      if (hasPrice) {
+        try {
+          const postResolutionRes = await Promise.all([
+            dvm.getPrice(
+              priceIdentifier.toString(),
+              expirationTimestamp.toNumber(),
+              { from: empAddress }
+            ),
+          ]);
+          resolvedPrice = parseFloat(fromWei(postResolutionRes.toString()));
+        } catch (err) {
+          console.error(`getPrice failed:`, err);
         }
-
-        // // Implementation 2: Call contract. This works for Kovan/MockOracle and is therefore useful for testing, but not mainnet since `getPrice` must be called with the overrideL `{from: emp.address}`.
-        // try {
-        //   const postResolutionRes = await Promise.all([
-        //     // `getPrice()` will fail on mainnet because the deployed `Voting.getPrice()` is required to be called from a registered contract, such as this EMP!
-        //     // TODO: Figure out a way to spoof the `from` parameter in this contract call and set to `emp.address`.
-        //     dvm.getPrice(
-        //       priceIdentifier.toString(),
-        //       expirationTimestamp.toNumber()
-        //     ),
-        //   ]);
-        //   resolvedPrice = parseFloat(fromWei(postResolutionRes.toString()));
-        // } catch (err) {
-        //   console.error(`getPrice failed:`, err);
-        // }
       }
 
       const newState: ContractState = {
@@ -119,8 +80,6 @@ const useContractState = () => {
 
   // get state on setting of contract
   useEffect(() => {
-    setState(initState);
-
     queryState();
   }, [dvm, priceIdentifier, expirationTimestamp]);
 

--- a/containers/DvmState.ts
+++ b/containers/DvmState.ts
@@ -81,8 +81,8 @@ const useContractState = () => {
         const matchingPriceRequest = data.priceRequests.find(
           (request: PriceRequestQuery) => {
             return (
-              request.identifier.id === "ETH/BTC" && //hexToUtf8(priceIdentifier)
-              request.time === "1592952397" //expirationTimestamp.toString()
+              request.identifier.id === hexToUtf8(priceIdentifier) &&
+              request.time === expirationTimestamp.toString()
             );
           }
         );

--- a/containers/EmpState.ts
+++ b/containers/EmpState.ts
@@ -24,6 +24,7 @@ interface ContractState {
   currentTime: BigNumber | null;
   isExpired: boolean | null;
   contractState: number | null;
+  finderAddress: string | null;
 }
 
 const initState = {
@@ -45,6 +46,7 @@ const initState = {
   currentTime: null,
   isExpired: null,
   contractState: null,
+  finderAddress: null,
 };
 
 const useContractState = () => {
@@ -78,6 +80,7 @@ const useContractState = () => {
         emp.withdrawalLiveness(),
         emp.getCurrentTime(),
         emp.contractState(),
+        emp.finder(),
       ]);
 
       const newState: ContractState = {
@@ -99,6 +102,7 @@ const useContractState = () => {
         currentTime: res[15] as BigNumber,
         isExpired: Number(res[15]) >= Number(res[0]),
         contractState: Number(res[16]),
+        finderAddress: res[17] as string, // address
       };
 
       setState(newState);

--- a/containers/EmpState.ts
+++ b/containers/EmpState.ts
@@ -22,6 +22,7 @@ interface ContractState {
   liquidationLiveness: BigNumber | null;
   withdrawalLiveness: BigNumber | null;
   currentTime: BigNumber | null;
+  isExpired: boolean | null;
 }
 
 const initState = {
@@ -41,6 +42,7 @@ const initState = {
   liquidationLiveness: null,
   withdrawalLiveness: null,
   currentTime: null,
+  isExpired: null,
 };
 
 const useContractState = () => {
@@ -92,6 +94,7 @@ const useContractState = () => {
         liquidationLiveness: res[13] as BigNumber,
         withdrawalLiveness: res[14] as BigNumber,
         currentTime: res[15] as BigNumber,
+        isExpired: Number(res[15]) >= Number(res[0]),
       };
 
       setState(newState);

--- a/containers/EmpState.ts
+++ b/containers/EmpState.ts
@@ -23,6 +23,7 @@ interface ContractState {
   withdrawalLiveness: BigNumber | null;
   currentTime: BigNumber | null;
   isExpired: boolean | null;
+  contractState: number | null;
 }
 
 const initState = {
@@ -43,6 +44,7 @@ const initState = {
   withdrawalLiveness: null,
   currentTime: null,
   isExpired: null,
+  contractState: null,
 };
 
 const useContractState = () => {
@@ -75,6 +77,7 @@ const useContractState = () => {
         emp.liquidationLiveness(),
         emp.withdrawalLiveness(),
         emp.getCurrentTime(),
+        emp.contractState(),
       ]);
 
       const newState: ContractState = {
@@ -95,6 +98,7 @@ const useContractState = () => {
         withdrawalLiveness: res[14] as BigNumber,
         currentTime: res[15] as BigNumber,
         isExpired: Number(res[15]) >= Number(res[0]),
+        contractState: Number(res[16]),
       };
 
       setState(newState);

--- a/features/contract-state/GeneralInfo.tsx
+++ b/features/contract-state/GeneralInfo.tsx
@@ -10,6 +10,8 @@ import Totals from "../../containers/Totals";
 import PriceFeed from "../../containers/PriceFeed";
 import Etherscan from "../../containers/Etherscan";
 
+import { DOCS_MAP } from "../../utils/getDocLinks";
+
 const Label = styled.span`
   color: #999999;
 `;
@@ -40,6 +42,7 @@ const GeneralInfo = () => {
     priceIdentifier: priceId,
     collateralRequirement: collReq,
     minSponsorTokens,
+    isExpired,
   } = empState;
   const { symbol: tokenSymbol } = Token.useContainer();
 
@@ -53,7 +56,8 @@ const GeneralInfo = () => {
     priceId !== null &&
     collReq !== null &&
     minSponsorTokens !== null &&
-    tokenSymbol !== null
+    tokenSymbol !== null &&
+    isExpired !== null
   ) {
     const expiryTimestamp = expiry.toString();
     const expiryDate = new Date(
@@ -77,7 +81,8 @@ const GeneralInfo = () => {
       priceIdUtf8,
       collReqPct,
       minSponsorTokensSymbol,
-      sponsorCount
+      sponsorCount,
+      isExpired ? "YES" : "NO"
     );
   } else {
     return renderComponent();
@@ -91,7 +96,8 @@ const GeneralInfo = () => {
     priceIdUtf8: string = defaultMissingDataDisplay,
     collReqPct: string = defaultMissingDataDisplay,
     minSponsorTokensSymbol: string = defaultMissingDataDisplay,
-    sponsorCount: string = defaultMissingDataDisplay
+    sponsorCount: string = defaultMissingDataDisplay,
+    isExpired: string = defaultMissingDataDisplay
   ) {
     return (
       <Box>
@@ -112,6 +118,17 @@ const GeneralInfo = () => {
           <Tooltip title={`Timestamp: ${expiryTimestamp}`} interactive>
             <span>{expiryDate} UTC</span>
           </Tooltip>
+        </Status>
+
+        <Status>
+          <Label>Is Expired: </Label>
+          <Link
+            href={DOCS_MAP.EXPIRY_SETTLEMENT}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <strong>{isExpired}</strong>
+          </Link>
         </Status>
 
         <Status>

--- a/features/manage-position/ManagePosition.tsx
+++ b/features/manage-position/ManagePosition.tsx
@@ -8,6 +8,7 @@ import Create from "./Create";
 import Deposit from "./Deposit";
 import Redeem from "./Redeem";
 import Withdraw from "./Withdraw";
+import SettleExpired from "./SettleExpired";
 import YourPosition from "./YourPosition";
 import YourWallet from "./YourWallet";
 
@@ -41,7 +42,7 @@ const Manager = () => {
         {method === "deposit" && <Deposit />}
         {method === "withdraw" && <Withdraw />}
         {method === "redeem" && <Redeem />}
-        {method === "settle" && <div>EXPIRY STUFF</div>}
+        {method === "settle" && <SettleExpired />}
       </Box>
     );
   } else {

--- a/features/manage-position/MethodSelector.tsx
+++ b/features/manage-position/MethodSelector.tsx
@@ -61,46 +61,40 @@ const MethodSelector = ({ method, handleChange }: IProps) => {
             onChange={handleChange}
             input={<BootstrapInput />}
           >
-            {_isExpired && (
-              <MenuItem value={"settle"}>
+            {_isExpired && [
+              <MenuItem key={"settle"} value={"settle"}>
                 <ListItemText
                   primary="Settle"
                   secondary="Settle expired tokens."
                 />
-              </MenuItem>
-            )}
-            {!_isExpired && (
-              <MenuItem value={"create"}>
+              </MenuItem>,
+            ]}
+            {!_isExpired && [
+              <MenuItem key={"create"} value={"create"}>
                 <ListItemText
                   primary="Create"
                   secondary="Mint new synthetic tokens."
                 />
-              </MenuItem>
-            )}
-            {!_isExpired && (
-              <MenuItem value={"deposit"}>
+              </MenuItem>,
+              <MenuItem key={"deposit"} value={"deposit"}>
                 <ListItemText
                   primary="Deposit"
                   secondary="Add to position collateral."
                 />
-              </MenuItem>
-            )}
-            {!_isExpired && (
-              <MenuItem value={"withdraw"}>
+              </MenuItem>,
+              <MenuItem key={"withdraw"} value={"withdraw"}>
                 <ListItemText
                   primary="Withdraw"
                   secondary="Remove position collateral"
                 />
-              </MenuItem>
-            )}
-            {!_isExpired && (
-              <MenuItem value={"redeem"}>
+              </MenuItem>,
+              <MenuItem key={"redeem"} value={"redeem"}>
                 <ListItemText
                   primary="Redeem"
                   secondary="Redeem synthetics for collateral."
                 />
-              </MenuItem>
-            )}
+              </MenuItem>,
+            ]}
           </Select>
         </FormWrapper>
       </Box>

--- a/features/manage-position/MethodSelector.tsx
+++ b/features/manage-position/MethodSelector.tsx
@@ -11,6 +11,8 @@ import Select from "@material-ui/core/Select";
 import ListItemText from "@material-ui/core/ListItemText";
 import { Method } from "./ManagePosition";
 
+import EmpState from "../../containers/EmpState";
+
 const BootstrapInput = withStyles((theme) => ({
   root: {
     "label + &": {
@@ -40,44 +42,70 @@ interface IProps {
 }
 
 const MethodSelector = ({ method, handleChange }: IProps) => {
-  return (
-    <Box py={2}>
-      <FormWrapper>
-        <InputLabel id="demo-simple-select-label">Actions</InputLabel>
-        <Select
-          labelId="demo-simple-select-label"
-          value={method}
-          onChange={handleChange}
-          input={<BootstrapInput />}
-        >
-          <MenuItem value={"create"}>
-            <ListItemText
-              primary="Create"
-              secondary="Mint new synthetic tokens."
-            />
-          </MenuItem>
-          <MenuItem value={"deposit"}>
-            <ListItemText
-              primary="Deposit"
-              secondary="Add to position collateral."
-            />
-          </MenuItem>
-          <MenuItem value={"withdraw"}>
-            <ListItemText
-              primary="Withdraw"
-              secondary="Remove position collateral"
-            />
-          </MenuItem>
-          <MenuItem value={"redeem"}>
-            <ListItemText
-              primary="Redeem"
-              secondary="Redeem synthetics for collateral."
-            />
-          </MenuItem>
-        </Select>
-      </FormWrapper>
-    </Box>
-  );
+  const { empState } = EmpState.useContainer();
+  const { isExpired } = empState;
+  if (isExpired !== null) {
+    return renderComponent(isExpired);
+  } else {
+    return renderComponent();
+  }
+
+  function renderComponent(_isExpired: boolean = false) {
+    return (
+      <Box py={2}>
+        <FormWrapper>
+          <InputLabel id="demo-simple-select-label">Actions</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            value={method}
+            onChange={handleChange}
+            input={<BootstrapInput />}
+          >
+            {_isExpired && (
+              <MenuItem value={"settle"}>
+                <ListItemText
+                  primary="Settle"
+                  secondary="Settle expired tokens."
+                />
+              </MenuItem>
+            )}
+            {!_isExpired && (
+              <MenuItem value={"create"}>
+                <ListItemText
+                  primary="Create"
+                  secondary="Mint new synthetic tokens."
+                />
+              </MenuItem>
+            )}
+            {!_isExpired && (
+              <MenuItem value={"deposit"}>
+                <ListItemText
+                  primary="Deposit"
+                  secondary="Add to position collateral."
+                />
+              </MenuItem>
+            )}
+            {!_isExpired && (
+              <MenuItem value={"withdraw"}>
+                <ListItemText
+                  primary="Withdraw"
+                  secondary="Remove position collateral"
+                />
+              </MenuItem>
+            )}
+            {!_isExpired && (
+              <MenuItem value={"redeem"}>
+                <ListItemText
+                  primary="Redeem"
+                  secondary="Redeem synthetics for collateral."
+                />
+              </MenuItem>
+            )}
+          </Select>
+        </FormWrapper>
+      </Box>
+    );
+  }
 };
 
 export default MethodSelector;

--- a/features/manage-position/MethodSelector.tsx
+++ b/features/manage-position/MethodSelector.tsx
@@ -50,7 +50,7 @@ const MethodSelector = ({ method, handleChange }: IProps) => {
     return renderComponent();
   }
 
-  function renderComponent(_isExpired: boolean = false) {
+  function renderComponent(contractHasExpired: boolean = false) {
     return (
       <Box py={2}>
         <FormWrapper>
@@ -61,40 +61,41 @@ const MethodSelector = ({ method, handleChange }: IProps) => {
             onChange={handleChange}
             input={<BootstrapInput />}
           >
-            {_isExpired && [
-              <MenuItem key={"settle"} value={"settle"}>
-                <ListItemText
-                  primary="Settle"
-                  secondary="Settle expired tokens."
-                />
-              </MenuItem>,
-            ]}
-            {!_isExpired && [
-              <MenuItem key={"create"} value={"create"}>
-                <ListItemText
-                  primary="Create"
-                  secondary="Mint new synthetic tokens."
-                />
-              </MenuItem>,
-              <MenuItem key={"deposit"} value={"deposit"}>
-                <ListItemText
-                  primary="Deposit"
-                  secondary="Add to position collateral."
-                />
-              </MenuItem>,
-              <MenuItem key={"withdraw"} value={"withdraw"}>
-                <ListItemText
-                  primary="Withdraw"
-                  secondary="Remove position collateral"
-                />
-              </MenuItem>,
-              <MenuItem key={"redeem"} value={"redeem"}>
-                <ListItemText
-                  primary="Redeem"
-                  secondary="Redeem synthetics for collateral."
-                />
-              </MenuItem>,
-            ]}
+            {contractHasExpired
+              ? [
+                  <MenuItem key={"settle"} value={"settle"}>
+                    <ListItemText
+                      primary="Settle"
+                      secondary="Settle expired tokens."
+                    />
+                  </MenuItem>,
+                ]
+              : [
+                  <MenuItem key={"create"} value={"create"}>
+                    <ListItemText
+                      primary="Create"
+                      secondary="Mint new synthetic tokens."
+                    />
+                  </MenuItem>,
+                  <MenuItem key={"deposit"} value={"deposit"}>
+                    <ListItemText
+                      primary="Deposit"
+                      secondary="Add to position collateral."
+                    />
+                  </MenuItem>,
+                  <MenuItem key={"withdraw"} value={"withdraw"}>
+                    <ListItemText
+                      primary="Withdraw"
+                      secondary="Remove position collateral"
+                    />
+                  </MenuItem>,
+                  <MenuItem key={"redeem"} value={"redeem"}>
+                    <ListItemText
+                      primary="Redeem"
+                      secondary="Redeem synthetics for collateral."
+                    />
+                  </MenuItem>,
+                ]}
           </Select>
         </FormWrapper>
       </Box>

--- a/features/manage-position/SettleExpired.tsx
+++ b/features/manage-position/SettleExpired.tsx
@@ -76,7 +76,6 @@ const SettleExpired = () => {
     const expiryDate = new Date(
       Number(expirationTimestamp) * 1000
     ).toLocaleString("en-GB", { timeZone: "UTC" });
-    const remainingTokens = Math.max(posTokens - tokenBalance, 0);
 
     const needsToRequestSettlementPrice = contractState === CONTRACT_STATE.OPEN;
 
@@ -234,16 +233,17 @@ const SettleExpired = () => {
         {collateralToReceive !== null && (
           <Box py={4}>
             <Typography>{`Resolved price (${priceIdUtf8} @ ${expiryDate}): ${resolvedPrice}`}</Typography>
-            <Typography>{`Total ${collSymbol} you will receive: ${collateralToReceive}`}</Typography>
-            <Typography>{`Redemption value of outstanding tokens in position: ${positionTRV}`}</Typography>
             <Typography>{`Collateral in position: ${posColl}`}</Typography>
+            <Typography>{`Redemption value of outstanding tokens in position: ${positionTRV}`}</Typography>
             <Typography>
               <strong>{`Excess collateral in position that you will receive: ${excessCollateral}`}</strong>
             </Typography>
             <Typography>
               <strong>{`Redemption value of tokens in your wallet: ${balanceTRV}`}</strong>
             </Typography>
-            <Typography>{`Tokens that will remain in position: ${remainingTokens}`}</Typography>
+            <br></br>
+            <br></br>
+            <Typography>{`Total ${collSymbol} you will receive: ${collateralToReceive}`}</Typography>
           </Box>
         )}
 

--- a/features/manage-position/SettleExpired.tsx
+++ b/features/manage-position/SettleExpired.tsx
@@ -1,0 +1,261 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { Box, Button, Typography, Grid } from "@material-ui/core";
+import { utils } from "ethers";
+
+import EmpContract from "../../containers/EmpContract";
+import EmpState from "../../containers/EmpState";
+import Collateral from "../../containers/Collateral";
+import Position from "../../containers/Position";
+import Token from "../../containers/Token";
+import Etherscan from "../../containers/Etherscan";
+import { DOCS_MAP } from "../../utils/getDocLinks";
+
+const Link = styled.a`
+  color: white;
+  font-size: 14px;
+`;
+
+const Important = styled(Typography)`
+  color: red;
+  background: black;
+  display: inline-block;
+`;
+
+enum CONTRACT_STATE {
+  OPEN,
+  PRICE_REQUESTED,
+  PRICE_RECEIVED,
+}
+
+const { parseBytes32String: hexToUtf8 } = utils;
+
+const SettleExpired = () => {
+  const { contract: emp } = EmpContract.useContainer();
+  const { empState } = EmpState.useContainer();
+  const {
+    priceIdentifier,
+    expirationTimestamp,
+    contractState,
+    isExpired,
+  } = empState;
+  const { symbol: collSymbol } = Collateral.useContainer();
+  const { tokens: posTokens, collateral: posColl } = Position.useContainer();
+  const {
+    symbol: tokenSymbol,
+    allowance: tokenAllowance,
+    decimals: tokenDec,
+    setMaxAllowance,
+    balance: tokenBalance,
+  } = Token.useContainer();
+  const { getEtherscanUrl } = Etherscan.useContainer();
+
+  const [hash, setHash] = useState<string | null>(null);
+  const [success, setSuccess] = useState<boolean | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  if (
+    posTokens !== null &&
+    posColl !== null &&
+    tokenBalance !== null &&
+    tokenDec !== null &&
+    tokenSymbol !== null &&
+    tokenAllowance !== null &&
+    emp !== null &&
+    priceIdentifier !== null &&
+    expirationTimestamp !== null &&
+    contractState !== null &&
+    isExpired !== null &&
+    isExpired // If contract has not expired, then do not render this component
+  ) {
+    const priceIdUtf8 = hexToUtf8(priceIdentifier);
+    const expiryDate = new Date(
+      Number(expirationTimestamp) * 1000
+    ).toLocaleString("en-GB", { timeZone: "UTC" });
+
+    const needsToRequestSettlementPrice = contractState === CONTRACT_STATE.OPEN;
+
+    // Error conditions for calling settle expired:
+    const needAllowance =
+      tokenAllowance !== "Infinity" && tokenAllowance < tokenBalance;
+    const canSettleTokens = tokenBalance > 0 || posTokens > 0;
+
+    const settleExpired = async () => {
+      if (canSettleTokens) {
+        setHash(null);
+        setSuccess(null);
+        setError(null);
+        try {
+          // This will fail if the DVM has not resolved a price yet.
+          const tx = await emp.settleExpired();
+          setHash(tx.hash as string);
+          await tx.wait();
+          setSuccess(true);
+        } catch (error) {
+          console.error(error);
+          setError(error);
+        }
+      } else {
+        setError(
+          new Error(
+            "You have no yUSD in your wallet or your position to settle"
+          )
+        );
+      }
+    };
+
+    const requestSettlementPrice = async () => {
+      if (needsToRequestSettlementPrice) {
+        setHash(null);
+        setSuccess(null);
+        setError(null);
+        try {
+          const tx = await emp.expire();
+          setHash(tx.hash as string);
+          await tx.wait();
+          setSuccess(true);
+        } catch (error) {
+          console.error(error);
+          setError(error);
+        }
+      } else {
+        setError(
+          new Error("A settlement price has already been requested or received")
+        );
+      }
+    };
+
+    return (
+      <Box>
+        <Box pt={2} pb={4}>
+          <Typography>
+            Settling expired tokens will redeem your{" "}
+            <strong>{tokenSymbol}</strong> tokens for{" "}
+            <strong>{collSymbol}</strong>. The amount of{" "}
+            <strong>{collSymbol}</strong> returned is determined by the
+            settlement price of {priceIdUtf8} for the expiration timestamp (
+            {expiryDate}).
+            <br></br>
+            <br></br>
+            You will receive the settlement value of your tokens (
+            <strong>{tokenSymbol} * settlement price</strong>) in{" "}
+            <strong>{collSymbol}</strong>.<br></br>
+            <br></br>
+            If you are a position sponsor, then you will also receive your
+            "excess collateral", which is the amount of{" "}
+            <strong>{collSymbol}</strong> in your position minus the settlement
+            value of outstanding <strong>{tokenSymbol}</strong> debt.
+            <br></br>
+            <br></br>
+            Learn more about the settlement process{" "}
+            <a
+              href={DOCS_MAP.EXPIRY_SETTLEMENT}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              here
+            </a>
+            .
+          </Typography>
+          <br></br>
+        </Box>
+
+        {needsToRequestSettlementPrice && (
+          <Box pb={4}>
+            <Important>
+              The {tokenSymbol} contract has expired, but you cannot settle your
+              tokens until a settlement price has been requested and resolved.
+            </Important>
+            <br></br>
+            <br></br>
+            <Button variant="contained" onClick={requestSettlementPrice}>
+              Request Settlement Price
+            </Button>
+          </Box>
+        )}
+
+        {!needsToRequestSettlementPrice && (
+          <>
+            <Box pb={4}>
+              <Important>
+                You cannot settle your tokens until a settlement price has been
+                resolved by the DVM.
+              </Important>
+            </Box>
+            <Grid container spacing={3}>
+              <Grid item md={4} sm={6} xs={12}>
+                <Box>
+                  {needAllowance && (
+                    <Button
+                      fullWidth
+                      variant="contained"
+                      onClick={setMaxAllowance}
+                      style={{ marginRight: `12px` }}
+                    >
+                      Max Approve
+                    </Button>
+                  )}
+                  {!needAllowance && (
+                    <Button
+                      fullWidth
+                      variant="contained"
+                      disabled={!canSettleTokens}
+                      onClick={settleExpired}
+                    >
+                      {`Settle ${tokenSymbol}`}
+                    </Button>
+                  )}
+                </Box>
+              </Grid>
+            </Grid>
+          </>
+        )}
+
+        {hash && (
+          <Box py={2}>
+            <Typography>
+              <strong>Tx Hash: </strong>
+              {hash ? (
+                <Link
+                  href={getEtherscanUrl(hash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {hash}
+                </Link>
+              ) : (
+                hash
+              )}
+            </Typography>
+          </Box>
+        )}
+        {success && (
+          <Box py={2}>
+            <Typography>
+              <strong>Transaction successful!</strong>
+            </Typography>
+          </Box>
+        )}
+        {error && (
+          <Box py={2}>
+            <Typography>
+              <span style={{ color: "red" }}>{error.message}</span>
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    );
+  } else {
+    return (
+      <Box>
+        <Box py={2}>
+          <Typography>
+            <i>This contract has not expired yet</i>
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+};
+
+export default SettleExpired;

--- a/features/manage-position/SettleExpired.tsx
+++ b/features/manage-position/SettleExpired.tsx
@@ -85,9 +85,9 @@ const SettleExpired = () => {
     const canSettleTokens = tokenBalance > 0 || posTokens > 0;
 
     // Calculate collateral to receive if price was resolved.
-    let positionTRV: number = -1;
-    let excessCollateral: number = -1;
-    let balanceTRV: number = -1;
+    let positionTRV: number | null = null;
+    let excessCollateral: number | null = null;
+    let balanceTRV: number | null = null;
     let collateralToReceive: number | null = null;
     if (resolvedPrice !== null) {
       positionTRV = posTokens * resolvedPrice;
@@ -114,7 +114,7 @@ const SettleExpired = () => {
       } else {
         setError(
           new Error(
-            "You have no yUSD in your wallet or your position to settle"
+            "You have no tokens in your wallet or your position to settle"
           )
         );
       }
@@ -230,22 +230,26 @@ const SettleExpired = () => {
           </>
         )}
 
-        {collateralToReceive !== null && (
-          <Box py={4}>
-            <Typography>{`Resolved price (${priceIdUtf8} @ ${expiryDate}): ${resolvedPrice}`}</Typography>
-            <Typography>{`Collateral in position: ${posColl}`}</Typography>
-            <Typography>{`Redemption value of outstanding tokens in position: ${positionTRV}`}</Typography>
-            <Typography>
-              <strong>{`Excess collateral in position that you will receive: ${excessCollateral}`}</strong>
-            </Typography>
-            <Typography>
-              <strong>{`Redemption value of tokens in your wallet: ${balanceTRV}`}</strong>
-            </Typography>
-            <br></br>
-            <br></br>
-            <Typography>{`Total ${collSymbol} you will receive: ${collateralToReceive}`}</Typography>
-          </Box>
-        )}
+        {resolvedPrice !== null &&
+          positionTRV !== null &&
+          excessCollateral !== null &&
+          balanceTRV !== null &&
+          collateralToReceive !== null && (
+            <Box py={4}>
+              <Typography>{`Resolved price (${priceIdUtf8} @ ${expiryDate}): ${resolvedPrice}`}</Typography>
+              <Typography>{`Collateral in position: ${posColl}`}</Typography>
+              <Typography>{`Redemption value of outstanding tokens in position: ${positionTRV}`}</Typography>
+              <Typography>
+                <strong>{`Excess collateral in position that you will receive: ${excessCollateral}`}</strong>
+              </Typography>
+              <Typography>
+                <strong>{`Redemption value of tokens in your wallet: ${balanceTRV}`}</strong>
+              </Typography>
+              <br></br>
+              <br></br>
+              <Typography>{`Total ${collSymbol} you will receive: ${collateralToReceive}`}</Typography>
+            </Box>
+          )}
 
         {hash && (
           <Box py={2}>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,6 +17,8 @@ import PriceFeed from "../containers/PriceFeed";
 import WethContract from "../containers/WethContract";
 import Etherscan from "../containers/Etherscan";
 import Balancer from "../containers/Balancer";
+import DvmContract from "../containers/DvmContract";
+import DvmState from "../containers/DvmState";
 
 import { ApolloProvider } from "@apollo/client";
 import { client } from "../apollo/client";
@@ -39,7 +41,13 @@ const WithStateContainerProviders = ({ children }: IProps) => (
                       <Totals.Provider>
                         <Etherscan.Provider>
                           <Position.Provider>
-                            <Balancer.Provider>{children}</Balancer.Provider>
+                            <Balancer.Provider>
+                              <DvmContract.Provider>
+                                <DvmState.Provider>
+                                  {children}
+                                </DvmState.Provider>
+                              </DvmContract.Provider>
+                            </Balancer.Provider>
                           </Position.Provider>
                         </Etherscan.Provider>
                       </Totals.Provider>

--- a/utils/getDocLinks.ts
+++ b/utils/getDocLinks.ts
@@ -9,4 +9,6 @@ export const DOCS_MAP: DocLinkMap = {
     "https://docs.umaproject.org/synthetic-tokens/explainer#slow-withdrawal",
   GCR:
     "https://docs.umaproject.org/synthetic-tokens/glossary#global-collateralization-ratio-gcr",
+  EXPIRY_SETTLEMENT:
+    "https://docs.umaproject.org/synthetic-tokens/explainer#redeeming-after-expiry",
 };


### PR DESCRIPTION
If a contract is expired, the user will only see the "Settle" method option. Otherwise, they will see "Create/Deposit/Redeem/Withdraw" but no "Settle"

It allows user to call `expire()` if a contract has expired but has not requested a price yet, and allows either a sponsor or a tokenholder to call `settleExpired()`. The dApp calls `Voting.hasPrice` in order to determine whether a price request has been resolved. Once a price has been resolved, a button to settle expired will appear.

It also provides a Max-Approve button for token holders.

Resolves #102 