### PR TITLE
Click to dispute logic

### DIFF
--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -159,12 +159,7 @@ const AllLiquidations = () => {
       return x.substr(0, 5) + "..." + x.substr(x.length - 5, x.length);
     };
 
-    const toggleDialog = () => {
-      setIsDialogShowing(!isDialogShowing);
-    };
-
     const handleOpenActionsDialog = (address: string) => {
-      console.log("opening for", address);
       setSelectedSponsor(address);
       setIsDialogShowing(true);
     };
@@ -380,7 +375,7 @@ const AllLiquidations = () => {
           </PageButtons>
         </TableContainer>
         <LiquidationActionDialog
-          handleClose={toggleDialog}
+          handleClose={() => setIsDialogShowing(!isDialogShowing)}
           isDialogShowing={isDialogShowing}
           selectedSponsor={selectedSponsor}
         />

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -19,6 +19,7 @@ import EmpSponsors from "../../containers/EmpSponsors";
 import Etherscan from "../../containers/Etherscan";
 
 import { isPricefeedInvertedFromTokenSymbol } from "../../utils/getOffchainPrice";
+import LiquidationActionDialog from "./LiquidationActionDialog";
 
 interface SortableTableHeaderProps {
   children: React.ReactNode;
@@ -45,6 +46,27 @@ const PageButtons = styled.div`
   justify-content: center;
   margin-top: 2em;
   margin-bottom: 2em;
+`;
+
+const MoreInfo = styled.a`
+  height: 23px;
+  width: 23px;
+  background-color: #303030;
+  border-radius: 50%;
+  display: inline-block;
+  text-align: center;
+  &:hover {
+    background-color: white;
+    transition: 0.3s;
+    cursor: pointer;
+  }
+`;
+
+const StyledTableRow = styled(TableRow)`
+  &:hover {
+    transition: 0.1s;
+    background-color: #636363;
+  }
 `;
 
 type FadedDiv = {
@@ -95,6 +117,10 @@ const AllLiquidations = () => {
     SORT_FIELD.TOKENS_LIQUIDATED
   );
 
+  // Extra info dialog
+  const [isDialogShowing, setIsDialogShowing] = useState<boolean>(false);
+  const [selectedSponsor, setSelectedSponsor] = useState<string | null>(null);
+
   // Set max page depending on # of liqs
   useEffect(() => {
     setMaxPage(1);
@@ -130,7 +156,17 @@ const AllLiquidations = () => {
     };
 
     const prettyAddress = (x: string) => {
-      return x.substr(0, 6) + "..." + x.substr(x.length - 6, x.length);
+      return x.substr(0, 5) + "..." + x.substr(x.length - 5, x.length);
+    };
+
+    const toggleDialog = () => {
+      setIsDialogShowing(!isDialogShowing);
+    };
+
+    const handleOpenActionsDialog = (address: string) => {
+      console.log("opening for", address);
+      setSelectedSponsor(address);
+      setIsDialogShowing(true);
     };
 
     const invertDisputablePrice = isPricefeedInvertedFromTokenSymbol(
@@ -211,113 +247,144 @@ const AllLiquidations = () => {
     };
 
     return (
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Sponsor</TableCell>
-              <TableCell align="right">
-                <SortableTableColumnHeader
-                  sortField={SORT_FIELD.LOCKED_COLLATERAL}
-                >
-                  Locked Collateral
-                  <br />({collSymbol}){" "}
-                </SortableTableColumnHeader>
-              </TableCell>
-              <TableCell align="right">
-                <SortableTableColumnHeader
-                  sortField={SORT_FIELD.TOKENS_LIQUIDATED}
-                >
-                  Synthetics
-                  <br />({tokenSymbol}){" "}
-                </SortableTableColumnHeader>
-              </TableCell>
-              <Tooltip
-                title={`If the index price at the liquidation timestamp was ${
-                  invertDisputablePrice ? `above` : `below`
-                } this, then the liquidation would be disputable`}
-                placement="top"
-              >
-                <TableCell align="right">
-                  <SortableTableColumnHeader
-                    sortField={SORT_FIELD.MAX_DISPUTABLE_PRICE}
-                  >
-                    {invertDisputablePrice ? `Min` : `Max`} Disputable Price{" "}
-                  </SortableTableColumnHeader>
+      <div>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <strong>
+                    Sponsor
+                    <br />
+                    Address
+                  </strong>
                 </TableCell>
-              </Tooltip>
-              <TableCell align="right">
-                <SortableTableColumnHeader
-                  sortField={SORT_FIELD.LIQUIDATION_TIMESTAMP}
-                >
-                  Liquidation Timestamp{" "}
-                </SortableTableColumnHeader>
-              </TableCell>
-              <TableCell align="right">Liquidation Receipt </TableCell>
-              <TableCell align="right">Status </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {reformattedLiquidationData.map((sponsor: string) => {
-              const liquidation = liquidations[sponsor];
-              return (
-                <TableRow key={sponsor}>
-                  <TableCell component="th" scope="row">
-                    <a href={getEtherscanUrl(sponsor)} target="_blank">
-                      {prettyAddress(sponsor)}
-                    </a>
-                  </TableCell>
-                  <TableCell align="right">
-                    {prettyBalance(Number(liquidation.lockedCollateral))}
-                  </TableCell>
-                  <TableCell align="right">
-                    {prettyBalance(Number(liquidation.tokensLiquidated))}
-                  </TableCell>
-                  <TableCell align="right">
-                    {prettyBalance(
-                      getDisputablePrice(liquidation.maxDisputablePrice)
-                    )}
-                  </TableCell>
-                  <TableCell align="right">
-                    {prettyDate(Number(liquidation.liquidationTimestamp))}
-                  </TableCell>
-                  <TableCell align="right">
-                    <a
-                      href={getEtherscanUrl(liquidation.liquidationReceipt)}
-                      target="_blank"
+                <TableCell align="right">
+                  <strong>
+                    <SortableTableColumnHeader
+                      sortField={SORT_FIELD.LIQUIDATION_TIMESTAMP}
                     >
-                      {prettyAddress(liquidation.liquidationReceipt)}
-                    </a>
-                  </TableCell>
+                      Liquidation Timestamp{" "}
+                    </SortableTableColumnHeader>
+                  </strong>
+                </TableCell>
+                <TableCell align="right">
+                  <strong>
+                    Liquidation
+                    <br />
+                    Status{" "}
+                  </strong>
+                </TableCell>
+                <TableCell align="right">
+                  <strong>
+                    <SortableTableColumnHeader
+                      sortField={SORT_FIELD.LOCKED_COLLATERAL}
+                    >
+                      Locked
+                      <br /> Collateral
+                      <br />({collSymbol}){" "}
+                    </SortableTableColumnHeader>
+                  </strong>
+                </TableCell>
+                <TableCell align="right" style={{ width: "100%" }}>
+                  <strong>
+                    <SortableTableColumnHeader
+                      sortField={SORT_FIELD.TOKENS_LIQUIDATED}
+                    >
+                      Liquidated <br />
+                      Synthetics
+                      <br />({tokenSymbol}){" "}
+                    </SortableTableColumnHeader>
+                  </strong>
+                </TableCell>
+                <Tooltip
+                  title={`If the index price at the liquidation timestamp was ${
+                    invertDisputablePrice ? `above` : `below`
+                  } this, then the liquidation would be disputable.`}
+                  placement="top"
+                >
                   <TableCell align="right">
-                    {translateLiquidationStatus(
-                      Number(liquidation.liquidationTimestamp),
-                      liquidation.status
-                    )}
+                    <strong>
+                      <SortableTableColumnHeader
+                        sortField={SORT_FIELD.MAX_DISPUTABLE_PRICE}
+                      >
+                        {invertDisputablePrice ? `Minimum` : `Maximum`}{" "}
+                        Disputable Price{" "}
+                      </SortableTableColumnHeader>
+                    </strong>
                   </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-        <PageButtons>
-          <div
-            onClick={() => {
-              setPage(page === 1 ? page : page - 1);
-            }}
-          >
-            <Arrow faded={page === 1 ? true : false}>←</Arrow>
-          </div>
-          {"Page " + page + " of " + maxPage}
-          <div
-            onClick={() => {
-              setPage(page === maxPage ? page : page + 1);
-            }}
-          >
-            <Arrow faded={page === maxPage ? true : false}>→</Arrow>
-          </div>
-        </PageButtons>
-      </TableContainer>
+                </Tooltip>
+
+                <TableCell align="right"></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {reformattedLiquidationData.map((sponsor: string) => {
+                const liquidation = liquidations[sponsor];
+                return (
+                  <StyledTableRow key={sponsor}>
+                    <TableCell component="th" scope="row">
+                      <a href={getEtherscanUrl(sponsor)} target="_blank">
+                        {prettyAddress(sponsor)}
+                      </a>
+                    </TableCell>
+                    <TableCell align="left">
+                      {prettyDate(Number(liquidation.liquidationTimestamp))}
+                    </TableCell>
+                    <TableCell align="right">
+                      {translateLiquidationStatus(
+                        Number(liquidation.liquidationTimestamp),
+                        liquidation.status
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      {prettyBalance(Number(liquidation.lockedCollateral))}
+                    </TableCell>
+                    <TableCell align="right">
+                      {prettyBalance(Number(liquidation.tokensLiquidated))}
+                    </TableCell>
+                    <TableCell align="right">
+                      {prettyBalance(
+                        getDisputablePrice(liquidation.maxDisputablePrice)
+                      )}
+                    </TableCell>
+
+                    <TableCell align="right">
+                      <MoreInfo
+                        onClick={() => handleOpenActionsDialog(sponsor)}
+                      >
+                        ⋮
+                      </MoreInfo>
+                    </TableCell>
+                  </StyledTableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+          <PageButtons>
+            <div
+              onClick={() => {
+                setPage(page === 1 ? page : page - 1);
+              }}
+            >
+              <Arrow faded={page === 1 ? true : false}>←</Arrow>
+            </div>
+            {"Page " + page + " of " + maxPage}
+            <div
+              onClick={() => {
+                setPage(page === maxPage ? page : page + 1);
+              }}
+            >
+              <Arrow faded={page === maxPage ? true : false}>→</Arrow>
+            </div>
+          </PageButtons>
+        </TableContainer>
+        <LiquidationActionDialog
+          handleClose={toggleDialog}
+          isDialogShowing={isDialogShowing}
+          selectedSponsor={selectedSponsor}
+        />
+      </div>
     );
   } else {
     return <></>;

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -119,7 +119,7 @@ const AllLiquidations = () => {
 
   // Extra info dialog
   const [isDialogShowing, setIsDialogShowing] = useState<boolean>(false);
-  const [liquidationId, setLiquidationId] = useState<string | null>(null);
+  const [sponsorPlusId, setSponsorPlusId] = useState<string | null>(null);
 
   // Set max page depending on # of liqs
   useEffect(() => {
@@ -160,7 +160,7 @@ const AllLiquidations = () => {
     };
 
     const handleOpenActionsDialog = (id: string) => {
-      setLiquidationId(id);
+      setSponsorPlusId(id);
       setIsDialogShowing(true);
     };
 
@@ -378,7 +378,7 @@ const AllLiquidations = () => {
         <LiquidationActionDialog
           handleClose={() => setIsDialogShowing(!isDialogShowing)}
           isDialogShowing={isDialogShowing}
-          liquidationId={liquidationId}
+          sponsorPlusId={sponsorPlusId}
         />
       </div>
     );

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -55,7 +55,7 @@ const Link = styled.a`
 interface DialogProps {
   handleClose(): any;
   isDialogShowing: boolean;
-  liquidationId: string | null;
+  sponsorPlusId: string | null;
 }
 
 const LiquidationActionDialog = (props: DialogProps) => {
@@ -99,9 +99,9 @@ const LiquidationActionDialog = (props: DialogProps) => {
   if (
     emp !== null &&
     liquidations !== null &&
-    props.liquidationId !== null &&
-    liquidations[props.liquidationId] &&
-    liquidations[props.liquidationId] !== null &&
+    props.sponsorPlusId !== null &&
+    liquidations[props.sponsorPlusId] &&
+    liquidations[props.sponsorPlusId] !== null &&
     isExpired !== null &&
     priceId !== null &&
     disputeBondPct !== null &&
@@ -114,7 +114,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
     tokenSymbol !== null &&
     finalFee !== null
   ) {
-    const liquidatedPosition = liquidations[props.liquidationId];
+    const liquidatedPosition = liquidations[props.sponsorPlusId];
     const invertDisputablePrice = isPricefeedInvertedFromTokenSymbol(
       tokenSymbol
     );
@@ -212,7 +212,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
         try {
           if (needCollateralAllowance()) await setMaxCollateralAllowance();
           const tx = await emp.dispute(
-            liquidatedPosition.liquidationId,
+            liquidatedPosition.sponsorPlusId,
             liquidatedPosition.sponsor
           );
           setHash(tx.hash as string);
@@ -328,7 +328,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                 </Status>
                 <Status>
                   <Label>Liquidation ID: </Label>
-                  {liquidatedPosition.liquidationId}
+                  {liquidatedPosition.sponsorPlusId}
                 </Status>
                 <Status>
                   <Label>Tokens liquidated: </Label>

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -1,0 +1,482 @@
+import styled from "styled-components";
+import { utils } from "ethers";
+const { formatUnits: fromWei, parseUnits: toWei } = utils;
+import { useState } from "react";
+
+import {
+  Box,
+  Container,
+  Typography,
+  Dialog,
+  Button,
+  Tooltip,
+} from "@material-ui/core";
+
+import EmpState from "../../containers/EmpState";
+import DvmState from "../../containers/DvmState";
+import Token from "../../containers/Token";
+import EmpSponsors from "../../containers/EmpSponsors";
+import EmpContract from "../../containers/EmpContract";
+import Collateral from "../../containers/Collateral";
+import Etherscan from "../../containers/Etherscan";
+
+import { DOCS_MAP } from "../../utils/getDocLinks";
+import { isPricefeedInvertedFromTokenSymbol } from "../../utils/getOffchainPrice";
+
+const Label = styled.span`
+  color: #999999;
+`;
+
+const Status = styled(Typography)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const PositionDialog = styled.div`
+  width: 100%;
+  border-color: white;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-bottom: 20px;
+`;
+
+const Important = styled(Typography)`
+  color: red;
+  background: black;
+  display: inline-block;
+`;
+
+const Link = styled.a`
+  color: white;
+  font-size: 14px;
+`;
+
+interface DialogProps {
+  handleClose(): any;
+  isDialogShowing: boolean;
+  selectedSponsor: string | null;
+}
+
+const LiquidationActionDialog = (props: DialogProps) => {
+  const { empState } = EmpState.useContainer();
+  const { dvmState } = DvmState.useContainer();
+  const { finalFee } = dvmState;
+  const { getEtherscanUrl } = Etherscan.useContainer();
+  const { contract: emp } = EmpContract.useContainer();
+
+  const { symbol: tokenSymbol } = Token.useContainer();
+  const {
+    symbol: collSymbol,
+    balance: collBalance,
+    allowance: collAllowance,
+    setMaxAllowance: setMaxCollateralAllowance,
+  } = Collateral.useContainer();
+  const { liquidations } = EmpSponsors.useContainer();
+
+  const [hash, setHash] = useState<string | null>(null);
+  const [success, setSuccess] = useState<boolean | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const {
+    disputeBondPct,
+    priceIdentifier: priceId,
+    liquidationLiveness,
+    withdrawalLiveness,
+    currentTime,
+  } = empState;
+
+  const prettyBalance = (x: number) => {
+    const x_string = x.toFixed(4);
+    return utils.commify(x_string);
+  };
+
+  const prettyAddress = (x: String) => {
+    return x.substr(0, 6) + "..." + x.substr(x.length - 6, x.length);
+  };
+
+  if (
+    props.selectedSponsor &&
+    liquidations[props.selectedSponsor] &&
+    liquidationLiveness &&
+    priceId &&
+    disputeBondPct
+  ) {
+    const liquidatedPosition = liquidations[props.selectedSponsor];
+    const invertDisputablePrice = isPricefeedInvertedFromTokenSymbol(
+      tokenSymbol
+    );
+    const priceIdUtf8 = utils.parseBytes32String(priceId);
+    const collBalanceNum = collBalance || 0;
+    const finalFeeNum = finalFee || 0;
+    const disputeBondNum = Number(fromWei(disputeBondPct)) || 0;
+
+    const needCollateralAllowance = () => {
+      if (collAllowance === null || finalFee == null) return true;
+      if (collAllowance === "Infinity") return false;
+      return collAllowance < finalFee;
+    };
+
+    const requiredDisputeBond =
+      Number(fromWei(disputeBondPct)) *
+      Number(liquidatedPosition.lockedCollateral);
+    const collRequired = finalFeeNum + requiredDisputeBond;
+    const collBalanceTooLow = collBalanceNum < collRequired;
+
+    const liquidationTimeRemaining =
+      Number(liquidatedPosition.liquidationTimestamp) +
+      Number(withdrawalLiveness) -
+      Number(currentTime);
+
+    const pendingLiquidationTimeString =
+      liquidationTimeRemaining > 0
+        ? Math.max(0, Math.floor(liquidationTimeRemaining / 3600)) +
+          ":" +
+          Math.max(0, Math.floor((liquidationTimeRemaining % 3600) / 60)) +
+          ":" +
+          Math.max(0, (liquidationTimeRemaining % 3600) % 60)
+        : "None";
+
+    const translateLiquidationStatus = (
+      liquidationTimestamp: number,
+      liquidationStatus: string
+    ) => {
+      const liquidationTimeRemaining =
+        liquidationTimestamp +
+        liquidationLiveness.toNumber() -
+        Math.floor(Date.now() / 1000);
+      if (liquidationTimeRemaining > 0 && liquidationStatus === "PreDispute") {
+        return {
+          status: "Liquidation Pending",
+          description:
+            "The liquidation is currently pending for the liveness period. The liquidation can be disputed during this time.",
+        };
+      } else if (
+        liquidationTimeRemaining <= 0 &&
+        liquidationStatus === "PreDispute"
+      ) {
+        return {
+          status: "Liquidation Succeeded",
+          description:
+            "The liquidation passed the liquidation liveness period undisputed.",
+        };
+      } else if (liquidationStatus === "PendingDispute") {
+        return {
+          status: "Dispute Pending",
+          description:
+            "The liquidation was disputed and will be resolved once the DVM returns a resolution price.",
+        };
+      } else if (liquidationStatus === "DisputeSucceeded") {
+        return {
+          status: "Dispute Succeeded",
+          description:
+            "The liquidation was disputed and the DVM deemed the liquidation invalid (valid dispute).",
+        };
+      } else if (liquidationStatus === "DisputeFailed") {
+        return {
+          status: "Dispute Failed",
+          description:
+            "The liquidation was disputed and the DVM deemed the liquidation valid (invalid dispute).",
+        };
+      } else {
+        return { status: "Unknown", description: "" };
+      }
+    };
+
+    const prettyDate = (x_secs: number) => {
+      return new Date(x_secs * 1000).toLocaleString("en-GB", {
+        timeZone: "UTC",
+      });
+    };
+
+    const getDisputablePrice = (x: string) => {
+      return invertDisputablePrice && parseFloat(x) !== 0
+        ? 1 / Number(x)
+        : Number(x);
+    };
+
+    const executeDispute = async () => {
+      if (emp && !collBalanceTooLow) {
+        setHash(null);
+        setSuccess(null);
+        setError(null);
+
+        try {
+          if (needCollateralAllowance()) await setMaxCollateralAllowance();
+          const tx = await emp.dispute(
+            liquidatedPosition.liquidationId,
+            liquidatedPosition.sponsor
+          );
+          setHash(tx.hash as string);
+          await tx.wait();
+
+          setSuccess(true);
+        } catch (error) {
+          console.error(error);
+          setError(error);
+        }
+      } else {
+        setError(new Error("Please check that you are connected."));
+      }
+    };
+
+    return (
+      <Dialog open={props.isDialogShowing} onClose={props.handleClose}>
+        <PositionDialog>
+          <Container>
+            <Box>
+              <Box>
+                <h1>Liquidation Info & Actions</h1>
+                <Status>
+                  <Label>Liquidation status: </Label>
+                  <Tooltip
+                    title={
+                      translateLiquidationStatus(
+                        Number(liquidatedPosition.liquidationTimestamp),
+                        liquidatedPosition.status
+                      ).description
+                    }
+                    placement="top"
+                  >
+                    <span>
+                      {" "}
+                      {
+                        translateLiquidationStatus(
+                          Number(liquidatedPosition.liquidationTimestamp),
+                          liquidatedPosition.status
+                        ).status
+                      }
+                    </span>
+                  </Tooltip>
+                </Status>
+                <Status>
+                  <Label>Liquidation Timestamp (UTC): </Label>
+                  <Tooltip
+                    title={`Liquidation unixTimestamp: ${liquidatedPosition.liquidationTimestamp}`}
+                    placement="top"
+                  >
+                    <span>
+                      {prettyDate(
+                        Number(liquidatedPosition.liquidationTimestamp)
+                      )}
+                    </span>
+                  </Tooltip>
+                </Status>
+                {pendingLiquidationTimeString !== "None" && (
+                  <Status>
+                    <Label>Liquidation liveness remaining: </Label>
+                    <Tooltip
+                      title={
+                        "Time remaining for the liquidation to be disputed. After this time no disputes will be accepted."
+                      }
+                      placement="top"
+                    >
+                      <span>{pendingLiquidationTimeString}</span>
+                    </Tooltip>
+                  </Status>
+                )}
+                <Status>
+                  <Label>Sponsor: </Label>
+                  <a
+                    href={getEtherscanUrl(liquidatedPosition.sponsor)}
+                    target="_blank"
+                  >
+                    {prettyAddress(liquidatedPosition.sponsor)}
+                  </a>
+                </Status>
+                <Status>
+                  <Label>Liquidator: </Label>
+                  <a
+                    href={getEtherscanUrl(liquidatedPosition.liquidator)}
+                    target="_blank"
+                  >
+                    {prettyAddress(liquidatedPosition.liquidator)}
+                  </a>
+                </Status>
+
+                <Status>
+                  <Label>Disputer: </Label>
+                  {liquidatedPosition.disputer && (
+                    <a
+                      href={getEtherscanUrl(liquidatedPosition.disputer)}
+                      target="_blank"
+                    >
+                      {prettyAddress(liquidatedPosition.disputer)}
+                    </a>
+                  )}
+                  {!liquidatedPosition.disputer && (
+                    <span>None(undisputed)</span>
+                  )}
+                </Status>
+                <Status>
+                  <Label>Liquidation Transaction: </Label>
+                  <a
+                    href={getEtherscanUrl(
+                      liquidatedPosition.liquidationReceipt
+                    )}
+                    target="_blank"
+                  >
+                    {prettyAddress(liquidatedPosition.liquidationReceipt)}
+                  </a>
+                </Status>
+                <Status>
+                  <Label>Liquidation ID: </Label>
+                  {liquidatedPosition.liquidationId}
+                </Status>
+                <Status>
+                  <Label>Tokens liquidated: </Label>
+                  {prettyBalance(
+                    Number(liquidatedPosition.tokensLiquidated)
+                  )}{" "}
+                  {tokenSymbol}
+                </Status>
+                <Status>
+                  <Label>Locked Collateral: </Label>
+                  {prettyBalance(
+                    Number(liquidatedPosition.lockedCollateral)
+                  )}{" "}
+                  {collSymbol}
+                </Status>
+                <Status>
+                  <Label>
+                    {invertDisputablePrice ? `Minimum` : `Maximum`} Disputable
+                    Price:{" "}
+                  </Label>
+
+                  {prettyBalance(
+                    getDisputablePrice(liquidatedPosition.maxDisputablePrice)
+                  )}
+                </Status>
+                <hr />
+                <Box pt={2}>
+                  <Typography>
+                    <strong>Dispute this liquidation</strong>
+                    <br></br>
+                  </Typography>
+                  {translateLiquidationStatus(
+                    Number(liquidatedPosition.liquidationTimestamp),
+                    liquidatedPosition.status
+                  ).status !== "Liquidation Pending" && (
+                    <span>
+                      <Typography>
+                        This liquidation can not be disputed as it is no longer
+                        in the pending state.
+                      </Typography>
+                      <Box textAlign="center" pt={3} pb={2}>
+                        <Button fullWidth variant="contained" disabled>
+                          Dispute Liquidation
+                        </Button>
+                      </Box>
+                    </span>
+                  )}
+                  {translateLiquidationStatus(
+                    Number(liquidatedPosition.liquidationTimestamp),
+                    liquidatedPosition.status
+                  ).status === "Liquidation Pending" && (
+                    <span>
+                      <Typography>
+                        This liquidation is currently in it's liveness period
+                        and can be disputed if you think it was invalid. In
+                        order for this liquidation to be invalid, the identifier{" "}
+                        {priceIdUtf8} would need to be greater than{" "}
+                        {prettyBalance(
+                          Number(liquidatedPosition.maxDisputablePrice)
+                        )}{" "}
+                        at the time of liquidation.
+                        <br></br>
+                        <br></br>
+                        To dispute this liquidation you will need to post a
+                        dispute bond of {disputeBondNum * 100}% of the
+                        collateral liquidated, equalling{" "}
+                        {prettyBalance(requiredDisputeBond)} {collSymbol}.
+                        Additionally, you will need to pay the final fee of{" "}
+                        {finalFee} {collSymbol}.<br></br>
+                        <br></br>
+                      </Typography>
+                      <Important>
+                        Exercise caution! An incorrect dispute will loose you
+                        the dispute bond AND final fee! See the{" "}
+                        <a
+                          href={DOCS_MAP.FINAL_FEE}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          UMA docs
+                        </a>
+                        .
+                      </Important>
+                      <Box textAlign="center" pt={3} pb={2}>
+                        {!collBalanceTooLow ? (
+                          <Button
+                            fullWidth
+                            variant="contained"
+                            onClick={executeDispute}
+                          >{`Dispute Liquidation`}</Button>
+                        ) : (
+                          <Button fullWidth variant="contained" disabled>
+                            Dispute Liquidation
+                          </Button>
+                        )}
+                      </Box>
+                      {needCollateralAllowance() && !collBalanceTooLow && (
+                        <Typography>
+                          Note you will need to sign two transactions one to
+                          approve {collSymbol} to pay the DVM final fee and post
+                          the dispute bond and a second to preform the dispute.
+                        </Typography>
+                      )}
+                      {collBalanceTooLow && (
+                        <Typography>
+                          Your wallet does not have enough collateral to pay the
+                          dispute bond and DVM final fee! You need, at minimum,{" "}
+                          {prettyBalance(collRequired)} {collSymbol} to preform
+                          this dispute.
+                        </Typography>
+                      )}
+                    </span>
+                  )}
+                </Box>
+              </Box>
+            </Box>
+            {hash && (
+              <Box py={2}>
+                <Typography>
+                  <strong>Tx Receipt: </strong>
+                  {hash ? (
+                    <Link
+                      href={getEtherscanUrl(hash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {hash}
+                    </Link>
+                  ) : (
+                    hash
+                  )}
+                </Typography>
+              </Box>
+            )}
+            {success && (
+              <Box py={2}>
+                <Typography>
+                  <strong>Transaction successful!</strong>
+                </Typography>
+              </Box>
+            )}
+            {error && (
+              <Box pt={2}>
+                <Typography>
+                  <span style={{ color: "red" }}>{error.message}</span>
+                </Typography>
+              </Box>
+            )}
+          </Container>
+        </PositionDialog>
+      </Dialog>
+    );
+  } else {
+    return <Box></Box>;
+  }
+};
+
+export default LiquidationActionDialog;

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -119,9 +119,6 @@ const LiquidationActionDialog = (props: DialogProps) => {
       tokenSymbol
     );
     const priceIdUtf8 = utils.parseBytes32String(priceId);
-    const collBalanceNum = collBalance;
-    const finalFeeNum = finalFee;
-    const disputeBondNum = Number(fromWei(disputeBondPct));
 
     const needCollateralAllowance = () => {
       if (collAllowance === "Infinity") return false;
@@ -131,8 +128,8 @@ const LiquidationActionDialog = (props: DialogProps) => {
     const requiredDisputeBond =
       Number(fromWei(disputeBondPct)) *
       Number(liquidatedPosition.lockedCollateral);
-    const collRequired = finalFeeNum + requiredDisputeBond;
-    const collBalanceTooLow = collBalanceNum < collRequired;
+    const collRequired = finalFee + requiredDisputeBond;
+    const collBalanceTooLow = collBalance < collRequired;
 
     const liquidationTimeRemaining =
       Number(liquidatedPosition.liquidationTimestamp) +
@@ -287,6 +284,17 @@ const LiquidationActionDialog = (props: DialogProps) => {
                   </Status>
                 )}
                 <Status>
+                  <Label>Liquidation Transaction: </Label>
+                  <a
+                    href={getEtherscanUrl(
+                      liquidatedPosition.liquidationReceipt
+                    )}
+                    target="_blank"
+                  >
+                    {prettyAddress(liquidatedPosition.liquidationReceipt)}
+                  </a>
+                </Status>
+                <Status>
                   <Label>Sponsor: </Label>
                   <a
                     href={getEtherscanUrl(liquidatedPosition.sponsor)}
@@ -317,17 +325,6 @@ const LiquidationActionDialog = (props: DialogProps) => {
                   {!liquidatedPosition.disputer && (
                     <span>None(undisputed)</span>
                   )}
-                </Status>
-                <Status>
-                  <Label>Liquidation Transaction: </Label>
-                  <a
-                    href={getEtherscanUrl(
-                      liquidatedPosition.liquidationReceipt
-                    )}
-                    target="_blank"
-                  >
-                    {prettyAddress(liquidatedPosition.liquidationReceipt)}
-                  </a>
                 </Status>
                 <Status>
                   <Label>Liquidation ID: </Label>
@@ -398,7 +395,8 @@ const LiquidationActionDialog = (props: DialogProps) => {
                           <br></br>
                           <br></br>
                           To dispute this liquidation you will need to post a
-                          dispute bond of {disputeBondNum * 100}% of the
+                          dispute bond of{" "}
+                          {Number(fromWei(disputeBondPct)) * 100}% of the
                           collateral liquidated, equalling{" "}
                           {prettyBalance(requiredDisputeBond)} {collSymbol}.
                           Additionally, you will need to pay the final fee of{" "}

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -96,11 +96,22 @@ const LiquidationActionDialog = (props: DialogProps) => {
   };
 
   if (
+    emp &&
+    liquidations &&
     props.selectedSponsor &&
     liquidations[props.selectedSponsor] &&
     liquidationLiveness &&
     priceId &&
-    disputeBondPct
+    disputeBondPct &&
+    collAllowance &&
+    collBalance &&
+    collSymbol &&
+    disputeBondPct &&
+    liquidationLiveness &&
+    withdrawalLiveness &&
+    currentTime &&
+    tokenSymbol &&
+    finalFee
   ) {
     const liquidatedPosition = liquidations[props.selectedSponsor];
     const invertDisputablePrice = isPricefeedInvertedFromTokenSymbol(
@@ -112,7 +123,6 @@ const LiquidationActionDialog = (props: DialogProps) => {
     const disputeBondNum = Number(fromWei(disputeBondPct)) || 0;
 
     const needCollateralAllowance = () => {
-      if (collAllowance === null || finalFee == null) return true;
       if (collAllowance === "Infinity") return false;
       return collAllowance < finalFee;
     };
@@ -196,7 +206,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
     };
 
     const executeDispute = async () => {
-      if (emp && !collBalanceTooLow) {
+      if (!collBalanceTooLow) {
         setHash(null);
         setSuccess(null);
         setError(null);
@@ -359,8 +369,9 @@ const LiquidationActionDialog = (props: DialogProps) => {
                   ).status !== "Liquidation Pending" && (
                     <span>
                       <Typography>
-                        This liquidation can not be disputed as it is no longer
-                        in the pending state.
+                        This liquidation can't be disputed as it is no longer in
+                        the pending state as it has passed the liquidation
+                        liveness period.
                       </Typography>
                       <Box textAlign="center" pt={3} pb={2}>
                         <Button fullWidth variant="contained" disabled>
@@ -406,17 +417,12 @@ const LiquidationActionDialog = (props: DialogProps) => {
                         .
                       </Important>
                       <Box textAlign="center" pt={3} pb={2}>
-                        {!collBalanceTooLow ? (
-                          <Button
-                            fullWidth
-                            variant="contained"
-                            onClick={executeDispute}
-                          >{`Dispute Liquidation`}</Button>
-                        ) : (
-                          <Button fullWidth variant="contained" disabled>
-                            Dispute Liquidation
-                          </Button>
-                        )}
+                        <Button
+                          fullWidth
+                          variant="contained"
+                          onClick={executeDispute}
+                          disabled={collBalanceTooLow}
+                        >{`Dispute Liquidation`}</Button>
                       </Box>
                       {needCollateralAllowance() && !collBalanceTooLow && (
                         <Typography>

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -102,6 +102,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
     props.selectedSponsor !== null &&
     liquidations[props.selectedSponsor] &&
     liquidations[props.selectedSponsor] !== null &&
+    isExpired !== null &&
     priceId !== null &&
     disputeBondPct !== null &&
     collAllowance !== null &&

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -137,14 +137,13 @@ const PositionActionsDialog = (props: DialogProps) => {
     collAllowance !== null &&
     priceId !== null
   ) {
+    const sponsorPosition = activeSponsors[props.selectedSponsor];
+
     const collateralToDepositNum = Number(collateralToDeposit) || 0;
     const maxTokensToLiquidateNum = Number(maxTokensToLiquidate) || 0;
 
-    const sponsorPosition = activeSponsors[props.selectedSponsor];
-
     const pendingWithdrawTimeRemaining =
       Number(sponsorPosition.withdrawalTimestamp) - Number(currentTime);
-
     const pendingTransferTimeRemaining =
       Number(sponsorPosition.TransferTimestamp) - Number(currentTime);
 

--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -181,7 +181,7 @@ const Deposit = () => {
         <Box py={4}>
           <Typography>{`Resulting CR: ${pricedResultantCR}`}</Typography>
           <Typography>
-            {`Resulting liquidation price: ${resultantLiquidationPrice} (${priceIdentifierUtf8}`}
+            {`Resulting liquidation price: ${resultantLiquidationPrice} (${priceIdentifierUtf8})`}
           </Typography>
         </Box>
 


### PR DESCRIPTION
This PR adds the ability to "click and dispute" a liquidation. Additionally, a dialog is added to show additional liquidation information in the "liquidations table". The screenshots below showcase this new functionality in different app states:

**Refined liquidations table**: The liquidations table was refined to have a more consistent look. 
1) Each section heading was made bold. 
2) Consistent widths and wrapping in each column.
3) removed one additional column to enable the full width without need to scroll.
4) changed the order of columns for consistency and to simplify the table.
5) hover color effect is the same as in PR #40.
![image](https://user-images.githubusercontent.com/12886084/89637683-da7ebb80-d8aa-11ea-9b12-015234cf763d.png)

**Additional liquidation information after liquidation liveness** If the timestamp is past the liquidation liveness then the dialog shows additional liquidation information that the table does not have. This can be seen below.
![image](https://user-images.githubusercontent.com/12886084/89638015-68f33d00-d8ab-11ea-8ae5-41073f6dffe9.png)

**Additional liquidation information _during liquidation liveness_**: If it is currently during the liquidation liveness, then the position can be disputed. The user is informed of the criteria for a dispute, the costs associated with it (final fee and bond) as well as told how many transactions they need to sign (based on their approval). There are two sub-states here: 
1) the user does not have enough collateral currency:
![image](https://user-images.githubusercontent.com/12886084/89638260-cd160100-d8ab-11ea-915e-0cb6a1aad48b.png)
and 2) the user has enough collateral currency:
![image](https://user-images.githubusercontent.com/12886084/89638229-bbccf480-d8ab-11ea-821c-f9d347aedb8d.png)

