### PR TITLE
EMPSponsors Container: use sponsor+liqID as key instead of sponsor to display multiple liquidations for sponsors

### DIFF
--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -12,6 +12,7 @@ export const EMP_DATA = gql`
         }
       }
       liquidations(first: 1000) {
+        id
         sponsor {
           id
         }

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -23,6 +23,10 @@ interface SponsorMap {
   [sponsor: string]: SponsorPositionState;
 }
 
+interface LiquidationMap {
+  [sponsorPlusId: string]: SponsorPositionState;
+}
+
 // Interfaces for GraphQl queries.
 interface PositionQuery {
   sponsor: { id: string };
@@ -31,6 +35,7 @@ interface PositionQuery {
 }
 
 interface LiquidationQuery {
+  id: string;
   sponsor: { id: string };
   liquidationId: string;
   liquidator: { address: string };
@@ -106,7 +111,7 @@ const useEmpSponsors = () => {
 
         if (empData) {
           let newPositions: SponsorMap = {};
-          let newLiquidations: SponsorMap = {};
+          let newLiquidations: LiquidationMap = {};
 
           const collReqFromWei = parseFloat(
             fromWei(collateralRequirement, collDecs)
@@ -142,7 +147,6 @@ const useEmpSponsors = () => {
           });
 
           empData.liquidations.forEach((liquidation: LiquidationQuery) => {
-            const sponsor = utils.getAddress(liquidation.sponsor.id);
             const liquidationCreatedEvent = liquidation.events.find(
               (e) => e.__typename === "LiquidationCreatedEvent"
             );
@@ -166,8 +170,8 @@ const useEmpSponsors = () => {
                 liquidation.tokensLiquidated !== "0" &&
                 liquidation.lockedCollateral !== "0"
               ) {
-                newLiquidations[sponsor] = {
-                  sponsor,
+                newLiquidations[liquidation.id] = {
+                  sponsor: utils.getAddress(liquidation.sponsor.id),
                   liquidator: liquidation.liquidator?.address,
                   disputer: liquidation.disputer?.address,
                   liquidationId: liquidation.liquidationId,

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -173,7 +173,8 @@ const useEmpSponsors = () => {
                 // The UMA subgraph uniquely identifies each liquidation with an "id" that concatenates
                 // the liquidated sponsor's address with the liquidation ID, for example:
                 // "0x1e17a75616cd74f5846b1b71622aa8e10ea26cc0-0"
-                newLiquidations[liquidation.id] = {
+                const sponsorAddressPlusId = liquidation.id;
+                newLiquidations[sponsorAddressPlusId] = {
                   sponsor: utils.getAddress(liquidation.sponsor.id),
                   liquidator: liquidation.liquidator?.address,
                   disputer: liquidation.disputer?.address,

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -170,6 +170,9 @@ const useEmpSponsors = () => {
                 liquidation.tokensLiquidated !== "0" &&
                 liquidation.lockedCollateral !== "0"
               ) {
+                // The UMA subgraph uniquely identifies each liquidation with an "id" that concatenates
+                // the liquidated sponsor's address with the liquidation ID, for example:
+                // "0x1e17a75616cd74f5846b1b71622aa8e10ea26cc0-0"
                 newLiquidations[liquidation.id] = {
                   sponsor: utils.getAddress(liquidation.sponsor.id),
                   liquidator: liquidation.liquidator?.address,

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -174,6 +174,7 @@ const AllLiquidations = () => {
     const reformattedLiquidationData = Object.keys(liquidations)
       .filter((sponsorAddressPlusId: string) => {
         return (
+          liquidations[sponsorAddressPlusId]?.maxDisputablePrice &&
           liquidations[sponsorAddressPlusId]?.tokensLiquidated &&
           liquidations[sponsorAddressPlusId]?.lockedCollateral &&
           liquidations[sponsorAddressPlusId]?.liquidationTimestamp

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -172,17 +172,18 @@ const AllLiquidations = () => {
     // then sorts the positions according to selected sort column,
     // and finally slices the array based on pagination selection.
     const reformattedLiquidationData = Object.keys(liquidations)
-      .filter((id: string) => {
+      .filter((sponsorAddressPlusId: string) => {
         return (
-          liquidations[id]?.maxDisputablePrice &&
-          liquidations[id]?.tokensLiquidated &&
-          liquidations[id]?.lockedCollateral &&
-          liquidations[id]?.liquidationTimestamp
+          liquidations[sponsorAddressPlusId]?.tokensLiquidated &&
+          liquidations[sponsorAddressPlusId]?.lockedCollateral &&
+          liquidations[sponsorAddressPlusId]?.liquidationTimestamp
         );
       })
-      .sort((idA: string, idB: string) => {
-        const fieldValueA = liquidations[idA][FIELD_TO_VALUE[sortedColumn]];
-        const fieldValueB = liquidations[idB][FIELD_TO_VALUE[sortedColumn]];
+      .sort((sponsorAddressPlusIdA: string, sponsorAddressPlusIdB: string) => {
+        const fieldValueA =
+          liquidations[sponsorAddressPlusIdA][FIELD_TO_VALUE[sortedColumn]];
+        const fieldValueB =
+          liquidations[sponsorAddressPlusIdB][FIELD_TO_VALUE[sortedColumn]];
         return Number(fieldValueA) > Number(fieldValueB)
           ? (sortDirection ? -1 : 1) * 1
           : (sortDirection ? -1 : 1) * -1;

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -172,19 +172,19 @@ const AllLiquidations = () => {
     // then sorts the positions according to selected sort column,
     // and finally slices the array based on pagination selection.
     const reformattedLiquidationData = Object.keys(liquidations)
-      .filter((sponsorAddressPlusId: string) => {
+      .filter((sponsorPlusId: string) => {
         return (
-          liquidations[sponsorAddressPlusId]?.maxDisputablePrice &&
-          liquidations[sponsorAddressPlusId]?.tokensLiquidated &&
-          liquidations[sponsorAddressPlusId]?.lockedCollateral &&
-          liquidations[sponsorAddressPlusId]?.liquidationTimestamp
+          liquidations[sponsorPlusId]?.maxDisputablePrice &&
+          liquidations[sponsorPlusId]?.tokensLiquidated &&
+          liquidations[sponsorPlusId]?.lockedCollateral &&
+          liquidations[sponsorPlusId]?.liquidationTimestamp
         );
       })
-      .sort((sponsorAddressPlusIdA: string, sponsorAddressPlusIdB: string) => {
+      .sort((sponsorPlusIdA: string, sponsorPlusIdB: string) => {
         const fieldValueA =
-          liquidations[sponsorAddressPlusIdA][FIELD_TO_VALUE[sortedColumn]];
+          liquidations[sponsorPlusIdA][FIELD_TO_VALUE[sortedColumn]];
         const fieldValueB =
-          liquidations[sponsorAddressPlusIdB][FIELD_TO_VALUE[sortedColumn]];
+          liquidations[sponsorPlusIdB][FIELD_TO_VALUE[sortedColumn]];
         return Number(fieldValueA) > Number(fieldValueB)
           ? (sortDirection ? -1 : 1) * 1
           : (sortDirection ? -1 : 1) * -1;

--- a/features/all-positions/AllLiquidations.tsx
+++ b/features/all-positions/AllLiquidations.tsx
@@ -172,19 +172,17 @@ const AllLiquidations = () => {
     // then sorts the positions according to selected sort column,
     // and finally slices the array based on pagination selection.
     const reformattedLiquidationData = Object.keys(liquidations)
-      .filter((sponsor: string) => {
+      .filter((id: string) => {
         return (
-          liquidations[sponsor]?.maxDisputablePrice &&
-          liquidations[sponsor]?.tokensLiquidated &&
-          liquidations[sponsor]?.lockedCollateral &&
-          liquidations[sponsor]?.liquidationTimestamp
+          liquidations[id]?.maxDisputablePrice &&
+          liquidations[id]?.tokensLiquidated &&
+          liquidations[id]?.lockedCollateral &&
+          liquidations[id]?.liquidationTimestamp
         );
       })
-      .sort((sponsorA: string, sponsorB: string) => {
-        const fieldValueA =
-          liquidations[sponsorA][FIELD_TO_VALUE[sortedColumn]];
-        const fieldValueB =
-          liquidations[sponsorB][FIELD_TO_VALUE[sortedColumn]];
+      .sort((idA: string, idB: string) => {
+        const fieldValueA = liquidations[idA][FIELD_TO_VALUE[sortedColumn]];
+        const fieldValueB = liquidations[idB][FIELD_TO_VALUE[sortedColumn]];
         return Number(fieldValueA) > Number(fieldValueB)
           ? (sortDirection ? -1 : 1) * 1
           : (sortDirection ? -1 : 1) * -1;
@@ -258,13 +256,16 @@ const AllLiquidations = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {reformattedLiquidationData.map((sponsor: string) => {
-              const liquidation = liquidations[sponsor];
+            {reformattedLiquidationData.map((id: string) => {
+              const liquidation = liquidations[id];
               return (
-                <TableRow key={sponsor}>
+                <TableRow key={id}>
                   <TableCell component="th" scope="row">
-                    <a href={getEtherscanUrl(sponsor)} target="_blank">
-                      {prettyAddress(sponsor)}
+                    <a
+                      href={getEtherscanUrl(liquidation.sponsor)}
+                      target="_blank"
+                    >
+                      {prettyAddress(liquidation.sponsor)}
                     </a>
                   </TableCell>
                   <TableCell align="right">


### PR DESCRIPTION
Look at the row for sponsor beginning 0x6B for the difference:

Current site only shows one liquidation for a sponsor:
![Screen Shot 2020-08-07 at 08 54 16](https://user-images.githubusercontent.com/9457025/89647584-c37ca100-d88b-11ea-94e7-417f2cae0591.png)

This fix slightly modifies the key used to store liquidation data to capture multiple liqs per sponsor:
![Screen Shot 2020-08-07 at 08 53 58](https://user-images.githubusercontent.com/9457025/89647574-c11a4700-d88b-11ea-881f-4bf72da96aca.png)



Signed-off-by: Nick Pai <npai.nyc@gmail.com>