### PR TITLE
Add kovan contracts

### DIFF
--- a/apollo/client.ts
+++ b/apollo/client.ts
@@ -4,21 +4,31 @@ import {
   ApolloLink,
   HttpLink,
 } from "@apollo/client";
+import { request } from "http";
 
-const umaLink = new HttpLink({
+const umaLinkKovan = new HttpLink({
+  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma-kovan",
+});
+const umaLinkMainnet = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/protofire/uma",
 });
 const balancerLink = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer",
 });
 
+// Uses ApolloLink's directional composition logic, docs: https://www.apollographql.com/docs/react/api/link/introduction/#directional-composition
+const umaLinks = ApolloLink.split(
+  (operation) => operation.getContext().clientName === "UMA42",
+  umaLinkKovan,
+  umaLinkMainnet
+);
+
 export const client = new ApolloClient({
-  uri: "https://api.thegraph.com/subgraphs/name/protofire/uma",
   cache: new InMemoryCache(),
+  // We handle more than 2 links by composing directional composition, idea from: https://www.loudnoises.us/next-js-two-apollo-clients-two-graphql-data-sources-the-easy-way/
   link: ApolloLink.split(
-    // Uses ApolloLink's directional composition logic, docs: https://www.apollographql.com/docs/react/api/link/introduction/#directional-composition
-    (operation) => operation.getContext().clientName === "UMA",
-    umaLink,
+    (operation) => operation.getContext().clientName.includes("UMA"),
+    umaLinks,
     balancerLink
   ),
 });

--- a/containers/Connection.ts
+++ b/containers/Connection.ts
@@ -13,6 +13,8 @@ type Block = ethers.providers.Block;
 type Network = ethers.providers.Network;
 type Signer = ethers.Signer;
 
+const SUPPORTED_NETWORK_IDS: number[] = [1, 42];
+
 function useConnection() {
   const [provider, setProvider] = useState<Provider | null>(null);
   const [onboard, setOnboard] = useState<OnboardApi | null>(null);
@@ -32,6 +34,9 @@ function useConnection() {
           setAddress(address);
         },
         network: async (networkId: any) => {
+          if (!SUPPORTED_NETWORK_IDS.includes(networkId)) {
+            alert("This dApp will work only with the Mainnet or Kovan network");
+          }
           onboard?.config({ networkId: networkId });
         },
         wallet: async (wallet: Wallet) => {

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -75,10 +75,7 @@ const useEmpSponsors = () => {
   // We set the poll interval to a very slow 5 seconds for now since the position states
   // are not expected to change much.
   // Source: https://www.apollographql.com/docs/react/data/queries/#polling
-  let clientName = "UMA";
-  if (network !== null) {
-    clientName += network.chainId.toString();
-  }
+  const clientName = `UMA${network?.chainId.toString()}`;
   const { loading, error, data } = useQuery(EMP_DATA, {
     context: { clientName: clientName },
     pollInterval: 5000,

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { utils } from "ethers";
 const fromWei = utils.formatUnits;
 
+import Connection from "./Connection";
 import EmpContract from "./EmpContract";
 import EmpState from "./EmpState";
 import Collateral from "./Collateral";
@@ -13,6 +14,7 @@ import { isPricefeedInvertedFromTokenSymbol } from "../utils/getOffchainPrice";
 
 import { useQuery } from "@apollo/client";
 import { EMP_DATA } from "../apollo/uma/queries";
+import { client } from "../apollo/client";
 
 // Interfaces for dApp state storage.
 interface SponsorPositionState {
@@ -61,6 +63,7 @@ interface FinancialContractQuery {
 }
 
 const useEmpSponsors = () => {
+  const { network } = Connection.useContainer();
   const { contract: emp } = EmpContract.useContainer();
   const { empState } = EmpState.useContainer();
   const { collateralRequirement } = empState;
@@ -72,8 +75,12 @@ const useEmpSponsors = () => {
   // We set the poll interval to a very slow 5 seconds for now since the position states
   // are not expected to change much.
   // Source: https://www.apollographql.com/docs/react/data/queries/#polling
+  let clientName = "UMA";
+  if (network !== null) {
+    clientName += network.chainId.toString();
+  }
   const { loading, error, data } = useQuery(EMP_DATA, {
-    context: { clientName: "UMA" },
+    context: { clientName: clientName },
     pollInterval: 5000,
   });
 

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -75,9 +75,9 @@ const useEmpSponsors = () => {
   // We set the poll interval to a very slow 5 seconds for now since the position states
   // are not expected to change much.
   // Source: https://www.apollographql.com/docs/react/data/queries/#polling
-  const clientName = `UMA${network?.chainId.toString()}`;
+  const subgraphToQuery = `UMA${network?.chainId.toString()}`;
   const { loading, error, data } = useQuery(EMP_DATA, {
-    context: { clientName: clientName },
+    context: { clientName: subgraphToQuery },
     pollInterval: 5000,
   });
 

--- a/containers/WethContract.ts
+++ b/containers/WethContract.ts
@@ -6,7 +6,13 @@ import { weth } from "@studydefi/money-legos/erc20";
 import Connection from "./Connection";
 
 function useContract() {
-  const { signer, address, block$, provider } = Connection.useContainer();
+  const {
+    signer,
+    address,
+    block$,
+    provider,
+    network,
+  } = Connection.useContainer();
   const [contract, setContract] = useState<ethers.Contract | null>(null);
   const [ethBalance, setEthBalance] = useState<BigNumberish | null>(null);
   const [wethBalance, setWethBalance] = useState<BigNumberish | null>(null);
@@ -41,11 +47,17 @@ function useContract() {
   }, [block$, contract, address, provider]);
 
   useEffect(() => {
-    if (signer) {
-      const instance = new ethers.Contract(weth.address, weth.abi, signer);
+    if (signer && network) {
+      const instance = new ethers.Contract(
+        network.chainId === 42
+          ? "0xd0a1e359811322d97991e03f863a0c30c2cf029c"
+          : weth.address, // Uses Kovan WETH contract if on Kovan, otherwise Mainnet WETH contract
+        weth.abi,
+        signer
+      );
       setContract(instance);
     }
-  }, [signer]);
+  }, [signer, network]);
 
   return { contract, ethBalance, wethBalance };
 }

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -212,7 +212,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
         try {
           if (needCollateralAllowance()) await setMaxCollateralAllowance();
           const tx = await emp.dispute(
-            liquidatedPosition.sponsorPlusId,
+            liquidatedPosition.liquidationId,
             liquidatedPosition.sponsor
           );
           setHash(tx.hash as string);

--- a/features/emp-selector/EMPs.ts
+++ b/features/emp-selector/EMPs.ts
@@ -1,5 +1,11 @@
-export const EMPs = [
-  "0x3f2D9eDd9702909Cf1F8C4237B7c4c5931F9C944", // ETHBTC
-  "0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1", // yCOMP
-  "0xb56C5f1fB93b1Fbd7c473926c87B6B9c4d0e21d5", // yUSD
-];
+export const EMPs: { [networkId: number]: string[] } = {
+  1: [
+    "0x3f2D9eDd9702909Cf1F8C4237B7c4c5931F9C944", // ETHBTC
+    "0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1", // yCOMP
+    "0xb56C5f1fB93b1Fbd7c473926c87B6B9c4d0e21d5", // yUSD
+  ],
+  42: [
+    "0x8f8e5d891BaCe2cf987A8E009C26e9fbF92caf20", // yUSD Kovan Sep20
+    "0xbf0e8ee7FD3d1fc42C8e305D4A495D50744Bc081", // yUSD Kovan Oct20
+  ],
+};

--- a/features/emp-selector/useEmpList.ts
+++ b/features/emp-selector/useEmpList.ts
@@ -13,15 +13,15 @@ export interface Emp {
 }
 
 const useEmpList = () => {
-  const { signer, provider } = Connection.useContainer();
+  const { signer, network } = Connection.useContainer();
   const [emps, setEmps] = useState<Emp[]>([]);
   const [loading, setLoading] = useState(false);
 
   const getEmps = async () => {
-    if (signer && provider) {
+    if (signer && network) {
       setLoading(true);
       // For each EMP address, find its token name and address
-      const promises = EMPs.map(async (empAddress: string) => {
+      const promises = EMPs[network.chainId].map(async (empAddress: string) => {
         const emp = new ethers.Contract(
           empAddress,
           uma.expiringMultiParty.abi,
@@ -47,7 +47,7 @@ const useEmpList = () => {
 
   useEffect(() => {
     getEmps();
-  }, [signer]);
+  }, [signer, network]);
 
   return {
     emps,

--- a/features/yield/Yield.tsx
+++ b/features/yield/Yield.tsx
@@ -7,12 +7,16 @@ import YieldCalculator from "./YieldCalculator";
 import BalancerData from "./BalancerData";
 import FarmingCalculator from "./FarmingCalculator";
 
+import Connection from "../../containers/Connection";
+
 const OutlinedContainer = styled.div`
   padding: 1rem;
   border: 1px solid #434343;
 `;
 
 const Yield = () => {
+  const { network } = Connection.useContainer();
+
   const [dialogTabIndex, setDialogTabIndex] = useState<string>(
     "farming-calculator"
   );
@@ -22,63 +26,74 @@ const Yield = () => {
   ) => {
     setDialogTabIndex(newAlignment);
   };
-  return (
-    <Box>
-      <Box pb={4}>
+
+  if (network === null || network.chainId !== 1) {
+    return (
+      <Box py={2}>
         <Typography>
-          <a
-            href="https://twitter.com/danrobinson/status/1169689525536215040"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            yTokens
-          </a>
-          , like yUSD, are expiring tokens with a fixed-rate return and are
-          redeemable for exactly 1 USD worth of collateral at expiry. To learn
-          more about yUSD see the UMA Medium post{" "}
-          <a
-            href="https://medium.com/uma-project/the-yield-dollar-on-uma-3a492e79069f"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            here
-          </a>
-          .
+          <i>Please first connect and set your network to Mainnet.</i>
         </Typography>
       </Box>
-      <Box pb={2}>
-        <OutlinedContainer>
-          <BalancerData />
-        </OutlinedContainer>
-      </Box>
-      <Box py={1} textAlign="center">
-        <ToggleButtonGroup
-          value={dialogTabIndex}
-          exclusive
-          onChange={handleAlignment}
-        >
-          <ToggleButton value="farming-calculator">
-            Liquidity Mining
-          </ToggleButton>
-          <ToggleButton value="yusd-calculator">yusd Yield</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
-      {dialogTabIndex === "farming-calculator" && (
-        <Box py={2}>
+    );
+  } else {
+    return (
+      <Box>
+        <Box pb={4}>
+          <Typography>
+            <a
+              href="https://twitter.com/danrobinson/status/1169689525536215040"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              yTokens
+            </a>
+            , like yUSD, are expiring tokens with a fixed-rate return and are
+            redeemable for exactly 1 USD worth of collateral at expiry. To learn
+            more about yUSD see the UMA Medium post{" "}
+            <a
+              href="https://medium.com/uma-project/the-yield-dollar-on-uma-3a492e79069f"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              here
+            </a>
+            .
+          </Typography>
+        </Box>
+        <Box pb={2}>
           <OutlinedContainer>
-            <FarmingCalculator />
+            <BalancerData />
           </OutlinedContainer>
         </Box>
-      )}
-      {dialogTabIndex === "yusd-calculator" && (
-        <Box py={2}>
-          <OutlinedContainer>
-            <YieldCalculator />
-          </OutlinedContainer>
+        <Box py={1} textAlign="center">
+          <ToggleButtonGroup
+            value={dialogTabIndex}
+            exclusive
+            onChange={handleAlignment}
+          >
+            <ToggleButton value="farming-calculator">
+              Liquidity Mining
+            </ToggleButton>
+            <ToggleButton value="yusd-calculator">yusd Yield</ToggleButton>
+          </ToggleButtonGroup>
         </Box>
-      )}
-    </Box>
-  );
+        {dialogTabIndex === "farming-calculator" && (
+          <Box py={2}>
+            <OutlinedContainer>
+              <FarmingCalculator />
+            </OutlinedContainer>
+          </Box>
+        )}
+        {dialogTabIndex === "yusd-calculator" && (
+          <Box py={2}>
+            <OutlinedContainer>
+              <YieldCalculator />
+            </OutlinedContainer>
+          </Box>
+        )}
+      </Box>
+    );
+  }
 };
 
 export default Yield;


### PR DESCRIPTION
- Switch seamlessly between Kovan and Mainnet contracts for WETH and EMP contracts
- Refuse to render `Yield` page when on Kovan because most of the balancer pool data here is irrelevant to Kovan
- Add support for Kovan subgraph URL

Question: 
- Is it possible to specify via `onboard.js` which networks we support? For example, I'd like this warning to show only if the user's network is not mainnet or kovan:
![Screen Shot 2020-08-13 at 15 27 34](https://user-images.githubusercontent.com/9457025/90180050-69447a00-dd7c-11ea-81fd-39a26c246118.png)


Other:
- Fixes bug in "Click To Dispute" feature where liquidation ID is incorrectly passed into `dispute()` method

Fixes #86 