### PR TITLE
feat(AllPositions): liquidation and position dialog enhancements

### DIFF
--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -133,7 +133,8 @@ const useEmpSponsors = () => {
               latestPrice
             );
             const liquidationPrice = getLiquidationPrice(
-              Number(position.collateral),
+              Number(position.collateral) -
+                Number(position.withdrawalRequestAmount),
               Number(position.tokensOutstanding),
               collReqFromWei,
               isPricefeedInvertedFromTokenSymbol(tokenSymbol)

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -203,6 +203,7 @@ const useEmpSponsors = () => {
                   maxDisputablePrice: maxDisputablePrice.toString(),
                   tokensLiquidated: liquidation.tokensLiquidated,
                   lockedCollateral: liquidation.lockedCollateral,
+                  liquidatedCollateral: liquidation.liquidatedCollateral,
                   status: liquidation.status,
                   liquidationTimestamp: liquidationCreatedEvent.timestamp,
                   liquidationReceipt: liquidationCreatedEvent.tx_hash,

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -126,15 +126,17 @@ const useEmpSponsors = () => {
 
           empData.positions.forEach((position: PositionQuery) => {
             const sponsor = utils.getAddress(position.sponsor.id);
+            const backingCollateral =
+              Number(position.collateral) -
+              Number(position.withdrawalRequestAmount);
 
             const cRatio = getCollateralRatio(
-              Number(position.collateral),
+              backingCollateral,
               Number(position.tokensOutstanding),
               latestPrice
             );
             const liquidationPrice = getLiquidationPrice(
-              Number(position.collateral) -
-                Number(position.withdrawalRequestAmount),
+              backingCollateral,
               Number(position.tokensOutstanding),
               collReqFromWei,
               isPricefeedInvertedFromTokenSymbol(tokenSymbol)
@@ -154,6 +156,7 @@ const useEmpSponsors = () => {
               newPositions[sponsor] = {
                 tokensOutstanding: position.tokensOutstanding,
                 collateral: position.collateral,
+                backingCollateral: backingCollateral.toString(),
                 cRatio: cRatio.toString(),
                 liquidationPrice: liquidationPrice.toString(),
                 pendingWithdraw: pendingWithdraw,

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -328,7 +328,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                 </Status>
                 <Status>
                   <Label>Liquidation ID: </Label>
-                  {liquidatedPosition.sponsorPlusId}
+                  {liquidatedPosition.liquidationId}
                 </Status>
                 <Status>
                   <Label>Tokens liquidated: </Label>
@@ -341,6 +341,20 @@ const LiquidationActionDialog = (props: DialogProps) => {
                   <Label>Locked Collateral: </Label>
                   {prettyBalance(
                     Number(liquidatedPosition.lockedCollateral)
+                  )}{" "}
+                  {collSymbol}
+                </Status>
+                <Status>
+                  <Tooltip
+                    title={
+                      "Equal to the locked collateral minus any requested withdrawal amount"
+                    }
+                    placement="top"
+                  >
+                    <Label>Backing Collateral: </Label>
+                  </Tooltip>
+                  {prettyBalance(
+                    Number(liquidatedPosition.liquidatedCollateral)
                   )}{" "}
                   {collSymbol}
                 </Status>

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { utils } from "ethers";
 const { formatUnits: fromWei, parseUnits: toWei } = utils;
-import { useState, MouseEvent } from "react";
+import { useState, MouseEvent, useEffect } from "react";
 
 import {
   Box,
@@ -283,6 +283,19 @@ const PositionActionsDialog = (props: DialogProps) => {
         setError(new Error("Please check that you are connected."));
       }
     };
+
+    useEffect(() => {
+      // Set min and max collPerToken params for the Liquidation dialog to
+      // approximately the current CRatio, +/- some error threshold.
+      const collPerToken =
+        Number(sponsorPosition.backingCollateral) /
+        Number(sponsorPosition.tokensOutstanding);
+      setMinCollPerToken((collPerToken * 0.95).toFixed(10));
+      setMaxCollPerToken((collPerToken * 1.05).toFixed(10));
+
+      // Set liquidation transaction deadline to a reasonable 30 mins to wait for it to be mined.
+      setDeadline((30 * 60).toString());
+    }, [sponsorPosition]);
 
     return (
       <Dialog open={props.isDialogShowing} onClose={props.handleClose}>

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -15,6 +15,7 @@ import {
   InputLabel,
   FormControl,
   MenuItem,
+  Tooltip,
 } from "@material-ui/core";
 
 import ToggleButton from "@material-ui/lab/ToggleButton";
@@ -304,6 +305,17 @@ const PositionActionsDialog = (props: DialogProps) => {
                   {prettyBalance(Number(sponsorPosition.collateral))}
                 </Status>
                 <Status>
+                  <Tooltip
+                    title={
+                      "Equal to the position collateral minus any requested withdrawal amount"
+                    }
+                    placement="top"
+                  >
+                    <Label>Backing Collateral({collSymbol}): </Label>
+                  </Tooltip>
+                  {prettyBalance(Number(sponsorPosition.backingCollateral))}
+                </Status>
+                <Status>
                   <Label>Minted Synthetics({tokenSymbol}): </Label>
                   {prettyBalance(Number(sponsorPosition.tokensOutstanding))}
                 </Status>
@@ -312,7 +324,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                   {prettyBalance(Number(sponsorPosition.cRatio))}
                 </Status>
                 <Status>
-                  <Label>Pending withdrawal: </Label>
+                  <Label>Pending Withdrawal: </Label>
                   {sponsorPosition.pendingWithdraw}
                 </Status>
                 {sponsorPosition.pendingWithdraw !== "No" && (
@@ -341,11 +353,11 @@ const PositionActionsDialog = (props: DialogProps) => {
                   </Status>
                 )}
                 <Status>
-                  <Label>Collateral ratio: </Label>
+                  <Label>Collateral Ratio: </Label>
                   {Number(sponsorPosition.cRatio).toFixed(4)}
                 </Status>
                 <Status>
-                  <Label>Liquidation price: </Label>
+                  <Label>Liquidation Price: </Label>
                   {Number(sponsorPosition.liquidationPrice).toFixed(4)}
                 </Status>
               </Box>


### PR DESCRIPTION
Position Dialog:
- CRatio and LiquidationPrice should account for requested withdrawal amount. Fixes #122 
- Should show backing collateral, not just locked collateral (accounts for withdrawal reqs)
- "Click to Liquidate" dialog should auto fill default values for `minCollPerToken` and `maxCollPerToken` as well as `liquidationDeadline`. Fixes #126 
- Preview: 
![Screen Shot 2020-08-19 at 12 36 30](https://user-images.githubusercontent.com/9457025/90666097-ea878b00-e21a-11ea-89ac-0f1fe7846821.png)


Liquidation Dialog: 
- Should show backing collateral, not just locked collateral (accounts for withdrawal reqs)
- (bug) Liquidation ID displayed correctly. Fixes #121 
- Preview: 
![Screen Shot 2020-08-19 at 12 20 34](https://user-images.githubusercontent.com/9457025/90666125-f5422000-e21a-11ea-95d3-81d8993ac9b0.png)
