### PR TITLE
fix(all-sponsors): Parse out `isEnded` positions from UMA graph query

### DIFF
--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -6,6 +6,7 @@ export const EMP_DATA = gql`
       id
       positions(first: 1000, where: { collateral_gt: 0 }) {
         collateral
+        isEnded
         tokensOutstanding
         withdrawalRequestPassTimestamp
         withdrawalRequestAmount

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -37,6 +37,7 @@ interface PositionQuery {
   withdrawalRequestPassTimestamp: string;
   withdrawalRequestAmount: string;
   transferPositionRequestPassTimestamp: string;
+  isEnded: boolean;
 }
 
 interface LiquidationQuery {
@@ -125,6 +126,8 @@ const useEmpSponsors = () => {
           );
 
           empData.positions.forEach((position: PositionQuery) => {
+            if (position.isEnded) return;
+
             const sponsor = utils.getAddress(position.sponsor.id);
             const backingCollateral =
               Number(position.collateral) -


### PR DESCRIPTION
Due to a subgraph bug, ended sponsor positions (following `settleExpired` calls by sponsors, for example) set `isEnded` to true, as expected, but do not reset `collateral` to 0 because this call reverts once the position actually is deleted. See the order of contract actions:

```
delete positions[msg.sender];
emit EndedSponsorPosition(msg.sender);
```