### PR TITLE
fix(manage-position) fix check for detecting 0 collateral

### DIFF
--- a/features/manage-position/Deposit.tsx
+++ b/features/manage-position/Deposit.tsx
@@ -63,7 +63,7 @@ const Deposit = () => {
     priceIdentifier !== null &&
     tokenSymbol !== null &&
     collSymbol !== null &&
-    posCollString !== "0" // If position has no collateral, then don't render deposit component.
+    Number(posCollString) > 0 // If position has no collateral, then don't render deposit component.
   ) {
     const collateralToDeposit = Number(collateral) || 0;
     const priceIdentifierUtf8 = hexToUtf8(priceIdentifier);

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -63,7 +63,7 @@ const Redeem = () => {
     tokenAllowance !== null &&
     emp !== null &&
     pendingWithdraw !== null &&
-    posCollString !== "0" // If position has no collateral, then don't render redeem component.
+    Number(posCollString) > 0 // If position has no collateral, then don't render redeem component.
   ) {
     const hasPendingWithdraw = pendingWithdraw === "Yes";
     const posTokens = Number(posTokensString);

--- a/features/manage-position/Withdraw.tsx
+++ b/features/manage-position/Withdraw.tsx
@@ -86,7 +86,7 @@ const Deposit = () => {
     priceIdentifier !== null &&
     collSymbol !== null &&
     tokenSymbol !== null &&
-    posCollString !== "0" // If position has no collateral, then don't render withdraw component.
+    Number(posCollString) > 0 // If position has no collateral, then don't render withdraw component.
   ) {
     const collateralToWithdraw = Number(collateral) || 0;
     const collReqFromWei = parseFloat(fromWei(collReq, collDec));


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

Redeem/Deposit/Withdraw shouldn't render if position has 0 collateral, I changed this to a number check rather than a string check which was incorrectly catching "0" instead of "0.0".