### PR TITLE
feat(click-to-liquidate): Block invalid min/maxCollPerToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Live frontend:
 
 - Production: https://tools.umaproject.org/
 
+## Install dependencies
+
+`yarn`
+
 ## Developing on Public Network
 
 Quick run on a public network (Mainnet and Kovan supported): `yarn dev`

--- a/README.md
+++ b/README.md
@@ -8,20 +8,7 @@ Live frontend:
 
 ## Manual testing
 
-First create a `.env` file with the following contents:
-
-```
-MAINNET_NODE_URL=https://mainnet.infura.io/v3/<INFURA_API_KEY>
-PRIV_KEY=0x123456789...
-```
-
-The following instructions will spin up a test chain forked off mainnet and also swap 10 ETH to DAI on Uniswap so that you have a healthy balance of ETH and DAI to test with. You can manually test the dapp with MetaMask in your browser this way.
-
-1. Run `npm run chain`.
-2. Copy the private key into MetaMask to access the account and connect to `localhost:8545`. Your balance should be ~990 ETH and a bunch of DAI.
-3. Test.
-
-Beware, it might be a bit slow and you might need to "reset" your account on MetaMask to clear the nonce.
+`yarn dev`
 
 ## Deployment and Hosting
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,26 @@ Live frontend:
 
 - Production: https://tools.umaproject.org/
 
-## Manual testing
+## Developing on Public Network
 
-`yarn dev`
+Quick run on a public network (Mainnet and Kovan supported): `yarn dev`
+
+## Developing on Mainnet-fork
+
+First create a `.env` file with the following contents:
+
+```
+MAINNET_NODE_URL=https://mainnet.infura.io/v3/<INFURA_API_KEY>
+PRIV_KEY=0x123456789...
+```
+
+The following instructions will spin up a test chain forked off mainnet and also swap 10 ETH to DAI on Uniswap so that you have a healthy balance of ETH and DAI to test with. You can manually test the dapp with MetaMask in your browser this way.
+
+1. Run `yarn chain`.
+2. Copy the private key into MetaMask to access the account and connect to `localhost:8545`. Your balance should be ~990 ETH and a bunch of DAI.
+3. Test.
+
+Beware, it might be a bit slow and you might need to "reset" your account on MetaMask to clear the nonce.
 
 ## Deployment and Hosting
 

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -520,18 +520,49 @@ const PositionActionsDialog = (props: DialogProps) => {
                           price.
                           <br></br>
                           <br></br>
-                          <Status>
-                            <Label>Current collateral/token ratio: </Label>
-                            {collRatio.toFixed(4)}
-                          </Status>
-                          <Status>
-                            <Label>Minimum profitable ratio: </Label>
-                            {minCollPerTokenToBeProfitable}
-                          </Status>
-                          <Status>
-                            <Label>Maximum liquidatable ratio: </Label>
-                            {maxCollPerTokenToBeValid}
-                          </Status>
+                          <Tooltip
+                            placement="top"
+                            title={`This can be calculated as (amount of collateral) divided by 
+                              (amount of tokens)`}
+                          >
+                            <Status>
+                              <Label>Current collateral/token ratio: </Label>
+                              {collRatio.toFixed(4)}
+                            </Status>
+                          </Tooltip>
+                          <Tooltip
+                            placement="top"
+                            title={`Liquidating a position whose collateral ratio is
+                              below ${minCollPerTokenToBeProfitable} would not be
+                              profitable using the estimated 
+                              ${utils.parseBytes32String(
+                                priceId
+                              )} price. This is
+                              because you must burn synthetic tokens in order to
+                              liquidate underlying collateral, and we estimate
+                              that each ${tokenSymbol} is worth
+                              ${latestPrice.toFixed(4)} of the collateral
+                              ${collSymbol}.`}
+                          >
+                            <Status>
+                              <Label>Minimum profitable ratio: </Label>
+                              {minCollPerTokenToBeProfitable}
+                            </Status>
+                          </Tooltip>
+                          <Tooltip
+                            placement="top"
+                            title={`Liquidating a position whose collateral ratio is
+                              greater than ${maxCollPerTokenToBeValid} would get
+                              disputed using the estimated
+                              ${utils.parseBytes32String(priceId)} price of 
+                              ${latestPrice.toFixed(4)} and the collateral
+                              requirement of ${parseFloat(fromWei(collReq))}.`}
+                          >
+                            <Status>
+                              <Label>Maximum liquidatable ratio: </Label>
+                              {maxCollPerTokenToBeValid}
+                            </Status>
+                          </Tooltip>
                         </Typography>
                         {minCollPerTokenNum <
                           minCollPerTokeToBeProfitablenNum && (

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -529,7 +529,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                           <Tooltip
                             placement="top"
                             title={`This can be calculated as (amount of collateral) divided by 
-                              (amount of tokens)`}
+                              (amount of tokens)`}.
                           >
                             <Status>
                               <Label>Current collateral/token ratio: </Label>

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -116,7 +116,8 @@ const PositionActionsDialog = (props: DialogProps) => {
     if (
       props.selectedSponsor !== null &&
       latestPrice !== null &&
-      collReq !== null
+      collReq !== null &&
+      tokenBalance !== null
     ) {
       const sponsorPosition = activeSponsors[props.selectedSponsor];
 
@@ -146,12 +147,17 @@ const PositionActionsDialog = (props: DialogProps) => {
       setMaxCollPerToken(_maxCollPerTokenToBeValid.toFixed(10));
 
       // Set max tokens to liquidate as full position size.
-      setMaxTokensToLiquidate(sponsorPosition.tokensOutstanding);
+      setMaxTokensToLiquidate(
+        Math.min(
+          Number(sponsorPosition.tokensOutstanding),
+          tokenBalance
+        ).toString()
+      );
     }
 
     // Set liquidation transaction deadline to a reasonable 30 mins to wait for it to be mined.
     setDeadline((30 * 60).toString());
-  }, [props.selectedSponsor, latestPrice, collReq]);
+  }, [props.selectedSponsor, latestPrice, collReq, tokenBalance]);
 
   const setDialogTab = (
     event: MouseEvent<HTMLElement>,

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -184,6 +184,12 @@ const PositionActionsDialog = (props: DialogProps) => {
     collAllowance !== null &&
     priceId !== null
   ) {
+    const minCollPerTokenNum = Number(minCollPerToken) || 0;
+    const maxCollPerTokenNum = Number(maxCollPerToken) || 0;
+    const minCollPerTokeToBeProfitablenNum =
+      Number(minCollPerTokenToBeProfitable) || 0;
+    const maxCollPerTokenToBeValidNum = Number(maxCollPerTokenToBeValid) || 0;
+
     const sponsorPosition = activeSponsors[props.selectedSponsor];
 
     const collateralToDepositNum = Number(collateralToDeposit) || 0;
@@ -332,7 +338,6 @@ const PositionActionsDialog = (props: DialogProps) => {
       }
     };
 
-    console.log(Number(minCollPerToken), minCollPerTokenToBeProfitable);
     return (
       <Dialog open={props.isDialogShowing} onClose={props.handleClose}>
         <PositionDialog>
@@ -517,8 +522,8 @@ const PositionActionsDialog = (props: DialogProps) => {
                             {maxCollPerTokenToBeValid}
                           </Status>
                         </Typography>
-                        {Number(minCollPerToken) <
-                          Number(minCollPerTokenToBeProfitable) && (
+                        {minCollPerTokenNum <
+                          minCollPerTokeToBeProfitablenNum && (
                           <>
                             <br></br>
                             <br></br>
@@ -543,8 +548,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                             </Important>
                           </>
                         )}
-                        {Number(maxCollPerToken) >
-                          Number(maxCollPerTokenToBeValid) && (
+                        {maxCollPerTokenNum > maxCollPerTokenToBeValidNum && (
                           <>
                             <br></br>
                             <br></br>
@@ -576,9 +580,9 @@ const PositionActionsDialog = (props: DialogProps) => {
                                 inputProps={{ min: "0" }}
                                 label={`Min collateral/token`}
                                 value={minCollPerToken}
-                                error={collRatio < Number(minCollPerToken)}
+                                error={collRatio < minCollPerTokenNum}
                                 helperText={
-                                  collRatio < Number(minCollPerToken) &&
+                                  collRatio < minCollPerTokenNum &&
                                   `Current collateral ratio of ${collRatio.toFixed(
                                     4
                                   )} is below the specified minimum ratio, transaction will revert.`
@@ -595,9 +599,9 @@ const PositionActionsDialog = (props: DialogProps) => {
                                 inputProps={{ min: "0" }}
                                 label={`Max collateral/token`}
                                 value={maxCollPerToken}
-                                error={collRatio > Number(maxCollPerToken)}
+                                error={collRatio > maxCollPerTokenNum}
                                 helperText={
-                                  collRatio > Number(maxCollPerToken) &&
+                                  collRatio > maxCollPerTokenNum &&
                                   `Current collateral ratio of ${collRatio.toFixed(
                                     4
                                   )} is above the specified maximum ratio, transaction will revert.`
@@ -665,8 +669,8 @@ const PositionActionsDialog = (props: DialogProps) => {
                                 deadline &&
                                 !collBalanceTooLow() &&
                                 !tokenBalanceTooLow &&
-                                collRatio >= Number(minCollPerToken) &&
-                                collRatio <= Number(maxCollPerToken)
+                                collRatio >= minCollPerTokenNum &&
+                                collRatio <= maxCollPerTokenNum
                               )
                             }
                           >{`Submit liquidation`}</Button>

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -588,7 +588,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                               <TextField
                                 fullWidth
                                 type="number"
-                                inputProps={{ min: "0" }}
+                                inputProps={{ min: "0", step: collRatio / 100 }}
                                 label={`Min collateral/token`}
                                 value={minCollPerToken}
                                 error={collRatio < minCollPerTokenNum}
@@ -607,7 +607,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                               <TextField
                                 fullWidth
                                 type="number"
-                                inputProps={{ min: "0" }}
+                                inputProps={{ min: "0", step: collRatio / 100 }}
                                 label={`Max collateral/token`}
                                 value={maxCollPerToken}
                                 error={collRatio > maxCollPerTokenNum}

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -529,7 +529,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                           <Tooltip
                             placement="top"
                             title={`This can be calculated as (amount of collateral) divided by 
-                              (amount of tokens)`}.
+                              (amount of tokens).`}
                           >
                             <Status>
                               <Label>Current collateral/token ratio: </Label>


### PR DESCRIPTION
Fixes #129 

Some previews:

New rows showing current, min, and max collateral ratios:
![Screen Shot 2020-08-26 at 09 33 41](https://user-images.githubusercontent.com/9457025/91311297-ee6a5e80-e780-11ea-9bd0-188b1485acc9.png)

Warning user if they set maxCollPerToken too high:
![Screen Shot 2020-08-26 at 09 33 51](https://user-images.githubusercontent.com/9457025/91311379-05a94c00-e781-11ea-8a07-336633ce9979.png)

Warning a user if they set minCollPerToken too low:
![Screen Shot 2020-08-26 at 09 34 06](https://user-images.githubusercontent.com/9457025/91311438-148ffe80-e781-11ea-8d2a-ec16ed2ae942.png)

Error shown to user if the position's cratio is outside their specified min/max bounds:
![Screen Shot 2020-08-26 at 09 43 35](https://user-images.githubusercontent.com/9457025/91311456-1c4fa300-e781-11ea-99e5-63da4b0f0877.png)

Rendering shown if only one bound is exceeded:
![Screen Shot 2020-08-26 at 09 43 43](https://user-images.githubusercontent.com/9457025/91311568-39847180-e781-11ea-9fdc-d30ef2811bce.png)
![Screen Shot 2020-08-26 at 09 43 53](https://user-images.githubusercontent.com/9457025/91311575-3be6cb80-e781-11ea-9871-7b8c1cf44e0e.png)

