### PR TITLE
fix(Create): floor max tokens to create instead of rounding to arbitrary precision

### DIFF
--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -97,7 +97,7 @@ const Create = () => {
     const maxTokensToCreate = _gcr > 0 ? collateral / _gcr : 0;
     // Unlike the min collateral, we're ok if we round down the tokens slightly as round down
     // can only increase the position's CR and maintain it above the GCR constraint.
-    setTokens(maxTokensToCreate.toFixed(4));
+    setTokens(Math.floor(maxTokensToCreate).toString());
   };
 
   if (

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -97,7 +97,7 @@ const Create = () => {
     const maxTokensToCreate = _gcr > 0 ? collateral / _gcr : 0;
     // Unlike the min collateral, we're ok if we round down the tokens slightly as round down
     // can only increase the position's CR and maintain it above the GCR constraint.
-    setTokens(Math.floor(maxTokensToCreate - 0.00005).toString());
+    setTokens((maxTokensToCreate - 0.0001).toFixed(4));
   };
 
   if (

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -97,7 +97,7 @@ const Create = () => {
     const maxTokensToCreate = _gcr > 0 ? collateral / _gcr : 0;
     // Unlike the min collateral, we're ok if we round down the tokens slightly as round down
     // can only increase the position's CR and maintain it above the GCR constraint.
-    setTokens(Math.floor(maxTokensToCreate - 0.0005).toString());
+    setTokens(Math.floor(maxTokensToCreate - 0.00005).toString());
   };
 
   if (

--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -97,7 +97,7 @@ const Create = () => {
     const maxTokensToCreate = _gcr > 0 ? collateral / _gcr : 0;
     // Unlike the min collateral, we're ok if we round down the tokens slightly as round down
     // can only increase the position's CR and maintain it above the GCR constraint.
-    setTokens(Math.floor(maxTokensToCreate).toString());
+    setTokens(Math.floor(maxTokensToCreate - 0.0005).toString());
   };
 
   if (


### PR DESCRIPTION
Avoids edge case where `max` sets tokens to a CR === GCR, `Math.floor(x - some_small_amount)` is cleaner.
Signed-off-by: Nick Pai <npai.nyc@gmail.com>