### PR TITLE
Add updated renBTC collateral contracts

### DIFF
--- a/features/emp-selector/EMPs.ts
+++ b/features/emp-selector/EMPs.ts
@@ -6,6 +6,7 @@ export const EMPs: { [networkId: number]: string[] } = {
     "0xE1Ee8D4C5dBA1c221840c08f6Cf42154435B9D52", // yUSD-OCT20
   ],
   42: [
+    "0x834adA34847ff7b9442cF269E0DE3091DC7BB895", // yUSD Kovan Sep20
     "0x11E612CFBBc7C45d8AAbFb97e76e7b343b6a1F2e", // yUSDBTC Kovan Oct20
     "0x50173b163B19F281086d411E86Ec349DCEE5ac00", // yUSDBTC Kovan Sep20
   ],

--- a/features/emp-selector/EMPs.ts
+++ b/features/emp-selector/EMPs.ts
@@ -6,7 +6,7 @@ export const EMPs: { [networkId: number]: string[] } = {
     "0xE1Ee8D4C5dBA1c221840c08f6Cf42154435B9D52", // yUSD-OCT20
   ],
   42: [
-    "0x834adA34847ff7b9442cF269E0DE3091DC7BB895", // yUSD Kovan Sep20
-    "0x8E6F002607227a4b3F2CCeaeE0f16FBA81B7d85C", // yUSD-BTC Kovan Sep20
+    "0x11E612CFBBc7C45d8AAbFb97e76e7b343b6a1F2e", // yUSDBTC Kovan Oct20
+    "0x50173b163B19F281086d411E86Ec349DCEE5ac00", // yUSDBTC Kovan Sep20
   ],
 };

--- a/utils/getOffchainPrice.ts
+++ b/utils/getOffchainPrice.ts
@@ -26,6 +26,10 @@ function _getKrakenPriceFromJSON(jsonData: any) {
   return Number(jsonData.result[tickerName].c[0]);
 }
 
+function _getBitstampPriceFromJSON(jsonData: any) {
+  return Number(jsonData.last);
+}
+
 // This function returns a type predicate that we can use to filter prices from a (number | null)[] into a number[],
 // source: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
 function isValidPrice<Price>(value: Price | null): value is Price {
@@ -57,7 +61,7 @@ export const PRICEFEED_PARAMS: PricefeedParamsMap = {
     source: [
       "https://api.binance.com/api/v3/avgPrice?symbol=BTCUSDT",
       "https://api.pro.coinbase.com/products/BTC-USD/trades?limit=1",
-      "https://api.kraken.com/0/public/Ticker?pair=BTCUSD",
+      "https://cors-anywhere.herokuapp.com/https://www.bitstamp.net/api/v2/ticker/btcusd",
     ],
   },
 };
@@ -111,6 +115,8 @@ export const getOffchainPriceFromTokenSymbol = async (symbol: string) => {
               return _getBinancePriceFromJSON(json);
             case url.includes("kraken"):
               return _getKrakenPriceFromJSON(json);
+            case url.includes("bitstamp"):
+              return _getBitstampPriceFromJSON(json);
             default:
               return null;
           }


### PR DESCRIPTION
1 EMP expires at 4pm UTC Sep 3, test out expiry
1 EMP expires at 10pm UTC Sep 3, to mirror production contract

Changes Kraken to Bitstamp price provider to mirror [UMIP7](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-7.md)
Signed-off-by: Nick Pai <npai.nyc@gmail.com>