### PR TITLE
fix(yield-calculator) fix pool inconsistancies

### DIFF
--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -73,7 +73,7 @@ const useBalancer = () => {
   const [selectedSwapTokenAddress, setSelectedSwapTokenAddress] = useState<
     string | null
   >(null);
-  const [poolTokenList, setPoolTokenList] = useState<string[] | null>();
+  const [poolTokenList, setPoolTokenList] = useState<string[] | null>(null);
   const [isYieldToken, setIsYieldToken] = useState<boolean>(false);
 
   const [usdPrice, setUsdPrice] = useState<number | null>(null);

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -33,22 +33,29 @@ interface PoolTokenQuery {
   balance: string;
 }
 
-interface YIELD_TOKEN {
-  [key: string]: string[];
+interface yieldPair {
+  [key: string]: string;
 }
-const YIELD_TOKENS: YIELD_TOKEN = {
-  "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5": [
-    "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5".toLowerCase(),
-    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
-  ], // yUSDETH-SEP20
-  "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4": [
-    "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4".toLowerCase(),
-    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
-  ], // yUSDETH-Oct20
-  "0x208D174775dc39fe18B1b374972F77ddEc6c0F73": [
-    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
-    "0x208d174775dc39fe18b1b374972f77ddec6c0f73".toLowerCase(),
-  ], // uUSDrBTC-OCT
+
+interface yieldToken {
+  [key: string]: yieldPair;
+}
+
+// The keys in this object are the synthetic token. the `token0` and `token1` are
+// the balancer pool key value pairs for the first and second token in the pool.
+const YIELD_TOKENS: yieldToken = {
+  "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5": {
+    token0: "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // yUSDETH-SEP20
+  "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4": {
+    token0: "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // yUSDETH-Oct20
+  "0x208D174775dc39fe18B1b374972F77ddEc6c0F73": {
+    token0: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    token1: "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
+  }, // uUSDrBTC-OCT
 };
 
 const useBalancer = () => {
@@ -107,11 +114,17 @@ const useBalancer = () => {
       setIsYieldToken(IS_YIELD_TOKEN);
       if (IS_YIELD_TOKEN) {
         setSelectedTokenAddress(tokenAddress.toLowerCase());
-        setPoolTokenList(YIELD_TOKENS[tokenAddress]);
+        setPoolTokenList([
+          YIELD_TOKENS[tokenAddress].token0.toLowerCase(),
+          YIELD_TOKENS[tokenAddress].token1.toLowerCase(),
+        ]);
       } else {
         const defaultTokenAddress = Object.keys(YIELD_TOKENS)[0].toLowerCase();
         setSelectedTokenAddress(defaultTokenAddress);
-        setPoolTokenList(YIELD_TOKENS[defaultTokenAddress]);
+        setPoolTokenList([
+          YIELD_TOKENS[defaultTokenAddress].token0.toLowerCase(),
+          YIELD_TOKENS[defaultTokenAddress].token1.toLowerCase(),
+        ]);
       }
     }
   };

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -91,7 +91,6 @@ const useBalancer = () => {
     variables: { tokenId: selectedTokenAddress },
     pollInterval: 5000,
   });
-  console.log("poolTokenList", poolTokenList);
   const { loading: poolLoading, error: poolError, data: poolData } = useQuery(
     POOL(JSON.stringify(poolTokenList)),
     {
@@ -108,12 +107,6 @@ const useBalancer = () => {
       setIsYieldToken(IS_YIELD_TOKEN);
       if (IS_YIELD_TOKEN) {
         setSelectedTokenAddress(tokenAddress.toLowerCase());
-        console.log("tokenAddress.toLowerCase()", tokenAddress.toLowerCase());
-        console.log("YIELD_TOKENS", YIELD_TOKENS);
-        console.log(
-          "YIELD_TOKENS[tokenAddress.toLowerCase()]",
-          YIELD_TOKENS[tokenAddress]
-        );
         setPoolTokenList(YIELD_TOKENS[tokenAddress]);
       } else {
         const defaultTokenAddress = Object.keys(YIELD_TOKENS)[0].toLowerCase();
@@ -145,7 +138,6 @@ const useBalancer = () => {
     }
     if (!poolLoading && poolData) {
       const data = poolData.pools[0];
-      console.log("data", data);
       if (!data) return null;
 
       const shareHolders: SharesState = {};

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -33,10 +33,23 @@ interface PoolTokenQuery {
   balance: string;
 }
 
-const YIELD_TOKENS = [
-  "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5", // Sep20
-  "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4", // Oct20
-];
+interface YIELD_TOKEN {
+  [key: string]: string[];
+}
+const YIELD_TOKENS: YIELD_TOKEN = {
+  "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5": [
+    "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5".toLowerCase(),
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
+  ], // yUSDETH-SEP20
+  "0xB2FdD60AD80ca7bA89B9BAb3b5336c2601C020b4": [
+    "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4".toLowerCase(),
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
+  ], // yUSDETH-Oct20
+  "0x208D174775dc39fe18B1b374972F77ddEc6c0F73": [
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".toLowerCase(),
+    "0x208d174775dc39fe18b1b374972f77ddec6c0f73".toLowerCase(),
+  ], // uUSDrBTC-OCT
+};
 
 const useBalancer = () => {
   const { address, block$ } = Connection.useContainer();
@@ -53,7 +66,7 @@ const useBalancer = () => {
   const [selectedSwapTokenAddress, setSelectedSwapTokenAddress] = useState<
     string | null
   >(null);
-  const [poolTokenList, setPoolTokenList] = useState<string[] | null>(null);
+  const [poolTokenList, setPoolTokenList] = useState<string[] | null>();
   const [isYieldToken, setIsYieldToken] = useState<boolean>(false);
 
   const [usdPrice, setUsdPrice] = useState<number | null>(null);
@@ -78,6 +91,7 @@ const useBalancer = () => {
     variables: { tokenId: selectedTokenAddress },
     pollInterval: 5000,
   });
+  console.log("poolTokenList", poolTokenList);
   const { loading: poolLoading, error: poolError, data: poolData } = useQuery(
     POOL(JSON.stringify(poolTokenList)),
     {
@@ -90,16 +104,21 @@ const useBalancer = () => {
   const initializeTokenAddress = () => {
     if (tokenAddress !== null) {
       setSelectedSwapTokenAddress(defaultSwapTokenAddress);
-
-      const IS_YIELD_TOKEN = YIELD_TOKENS.includes(tokenAddress);
+      const IS_YIELD_TOKEN = Object.keys(YIELD_TOKENS).includes(tokenAddress);
       setIsYieldToken(IS_YIELD_TOKEN);
       if (IS_YIELD_TOKEN) {
         setSelectedTokenAddress(tokenAddress.toLowerCase());
-        setPoolTokenList([tokenAddress.toLowerCase(), defaultSwapTokenAddress]);
+        console.log("tokenAddress.toLowerCase()", tokenAddress.toLowerCase());
+        console.log("YIELD_TOKENS", YIELD_TOKENS);
+        console.log(
+          "YIELD_TOKENS[tokenAddress.toLowerCase()]",
+          YIELD_TOKENS[tokenAddress]
+        );
+        setPoolTokenList(YIELD_TOKENS[tokenAddress]);
       } else {
-        const defaultTokenAddress = YIELD_TOKENS[0].toLowerCase();
+        const defaultTokenAddress = Object.keys(YIELD_TOKENS)[0].toLowerCase();
         setSelectedTokenAddress(defaultTokenAddress);
-        setPoolTokenList([defaultTokenAddress, defaultSwapTokenAddress]);
+        setPoolTokenList(YIELD_TOKENS[defaultTokenAddress]);
       }
     }
   };
@@ -126,6 +145,8 @@ const useBalancer = () => {
     }
     if (!poolLoading && poolData) {
       const data = poolData.pools[0];
+      console.log("data", data);
+      if (!data) return null;
 
       const shareHolders: SharesState = {};
       data.shares.forEach((share: SharesQuery) => {

--- a/features/yield/BalancerData.tsx
+++ b/features/yield/BalancerData.tsx
@@ -1,5 +1,6 @@
 import { Typography, Grid } from "@material-ui/core";
 import styled from "styled-components";
+import Token from "../../containers/Token";
 
 import Balancer from "../../containers/Balancer";
 
@@ -19,6 +20,7 @@ const Link = styled.a`
 
 const BalancerData = () => {
   const { poolAddress, usdPrice, pool, shares } = Balancer.useContainer();
+  const { symbol: tokenSymbol } = Token.useContainer();
 
   if (
     poolAddress !== null &&
@@ -60,7 +62,7 @@ const BalancerData = () => {
     return (
       <span>
         <Typography variant="h5" style={{ marginBottom: "10px" }}>
-          yUSD Pool Metrics{" "}
+          {tokenSymbol} Pool Metrics{" "}
           <Link
             href={balancerPoolUrl}
             target="_blank"
@@ -77,7 +79,7 @@ const BalancerData = () => {
             </Status>
             <Status>
               <Label>
-                - <i>yUSD</i>:{" "}
+                - <i>{tokenSymbol}</i>:{" "}
               </Label>
               {poolBalanceToken}
             </Status>

--- a/features/yield/FarmingCalculator.tsx
+++ b/features/yield/FarmingCalculator.tsx
@@ -23,9 +23,13 @@ const FarmingCalculator = () => {
   } = Balancer.useContainer();
 
   // Farming calculations for rolling between yUSD pools
-  const octPrice = getTokenPrice(YIELD_TOKENS[1].toLowerCase());
-  const sept20PoolData = getPoolDataForToken(YIELD_TOKENS[0].toLowerCase());
-  const oct20PoolData = getPoolDataForToken(YIELD_TOKENS[1].toLowerCase());
+  const octPrice = getTokenPrice(Object.keys(YIELD_TOKENS)[1].toLowerCase());
+  const sept20PoolData = getPoolDataForToken(
+    Object.keys(YIELD_TOKENS)[0].toLowerCase()
+  );
+  const oct20PoolData = getPoolDataForToken(
+    Object.keys(YIELD_TOKENS)[1].toLowerCase()
+  );
   const cutOffDateForRoll = Date.UTC(2020, 7, 28, 23, 0, 0, 0);
   const currentDate = new Date();
   const currentDateUTC = Date.UTC(

--- a/features/yield/FarmingCalculator.tsx
+++ b/features/yield/FarmingCalculator.tsx
@@ -3,6 +3,7 @@ import { Box, TextField, Typography, Grid } from "@material-ui/core";
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import Balancer from "../../containers/Balancer";
+import Token from "../../containers/Token";
 
 import { getUmaPrice } from "../../utils/getUmaTokenPrice";
 
@@ -21,6 +22,7 @@ const FarmingCalculator = () => {
     YIELD_TOKENS,
     poolAddress,
   } = Balancer.useContainer();
+  const { symbol: tokenSymbol } = Token.useContainer();
 
   // Farming calculations for rolling between yUSD pools
   const octPrice = getTokenPrice(Object.keys(YIELD_TOKENS)[1].toLowerCase());
@@ -168,9 +170,9 @@ const FarmingCalculator = () => {
       <br></br>
       <Typography>
         During the liquidity mining program 25k UMA rewards will be paid out to
-        LP providers in certain yUSD balancer pools. Rewards are calculated as a
-        pro-rata contribution to the liquidity pool. To learn more about the
-        liquidity mining program see UMA Medium post{" "}
+        LP providers in certain yield token balancer pools. Rewards are
+        calculated as a pro-rata contribution to the liquidity pool. To learn
+        more about the liquidity mining program see UMA Medium post{" "}
         <a
           href="https://medium.com/uma-project/liquidity-mining-on-uma-is-now-live-5f6cb0bd53ee"
           target="_blank"
@@ -220,7 +222,7 @@ const FarmingCalculator = () => {
                 <TextField
                   fullWidth
                   type="number"
-                  label="yUSD added to pool"
+                  label={`${tokenSymbol} added to pool`}
                   value={yUSDAdded}
                   onChange={(e) => setyUSDAdded(e.target.value)}
                   variant="outlined"

--- a/features/yield/Yield.tsx
+++ b/features/yield/Yield.tsx
@@ -9,6 +9,7 @@ import FarmingCalculator from "./FarmingCalculator";
 
 import Connection from "../../containers/Connection";
 import Balancer from "../../containers/Balancer";
+import Token from "../../containers/Token";
 
 const OutlinedContainer = styled.div`
   padding: 1rem;
@@ -18,6 +19,7 @@ const OutlinedContainer = styled.div`
 const Yield = () => {
   const { network } = Connection.useContainer();
   const { isYieldToken } = Balancer.useContainer();
+  const { symbol: tokenSymbol } = Token.useContainer();
 
   const [dialogTabIndex, setDialogTabIndex] = useState<string>(
     "farming-calculator"
@@ -35,7 +37,7 @@ const Yield = () => {
         <Typography>
           <i>
             Please first connect and set your network to Mainnet, and then
-            select a yield token (i.e. yUSD).
+            select a yield token (i.e. yUSD-OCT20).
           </i>
         </Typography>
       </Box>
@@ -52,9 +54,9 @@ const Yield = () => {
             >
               yTokens
             </a>
-            , like yUSD, are expiring tokens with a fixed-rate return and are
-            redeemable for exactly 1 USD worth of collateral at expiry. To learn
-            more about yUSD see the UMA Medium post{" "}
+            , like {tokenSymbol}, are expiring tokens with a fixed-rate return
+            and are redeemable for exactly 1 USD worth of collateral at expiry.
+            To learn more about {tokenSymbol} see the UMA Medium post{" "}
             <a
               href="https://medium.com/uma-project/the-yield-dollar-on-uma-3a492e79069f"
               target="_blank"
@@ -87,7 +89,7 @@ const Yield = () => {
             <ToggleButton value="farming-calculator">
               Liquidity Mining
             </ToggleButton>
-            <ToggleButton value="yusd-calculator">yusd Yield</ToggleButton>
+            <ToggleButton value="yusd-calculator">yield dollar</ToggleButton>
           </ToggleButtonGroup>
         </Box>
         {dialogTabIndex === "farming-calculator" && (

--- a/features/yield/YieldCalculator.tsx
+++ b/features/yield/YieldCalculator.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import styled from "styled-components";
 import EmpState from "../../containers/EmpState";
 import Balancer from "../../containers/Balancer";
+import Token from "../../containers/Token";
 
 const FormInput = styled.div`
   margin-top: 20px;
@@ -22,6 +23,7 @@ const YieldCalculator = () => {
   const { empState } = EmpState.useContainer();
   const { expirationTimestamp } = empState;
   const { usdPrice } = Balancer.useContainer();
+  const { symbol: tokenSymbol } = Token.useContainer();
 
   const [tokenPrice, setTokenPrice] = useState<string>("");
   const [daysToExpiry, setDaysToExpiry] = useState<string>("");
@@ -120,7 +122,7 @@ const YieldCalculator = () => {
               <TextField
                 fullWidth
                 type="number"
-                label="Current yUSD Price (USD)"
+                label={`Current ${tokenSymbol} Price (USD)`}
                 value={tokenPrice}
                 onChange={(e) => setTokenPrice(e.target.value)}
                 variant="outlined"
@@ -141,7 +143,7 @@ const YieldCalculator = () => {
                 value={daysToExpiry}
                 onChange={(e) => setDaysToExpiry(e.target.value)}
                 inputProps={{ min: "0", step: "1" }}
-                helperText={`Days to expiry for chosen EMP: ${daysToExpiry}`}
+                helperText={`Days to expiry for EMP: ${daysToExpiry}`}
                 variant="outlined"
                 InputLabelProps={{
                   shrink: true,

--- a/features/yield/YieldCalculator.tsx
+++ b/features/yield/YieldCalculator.tsx
@@ -92,9 +92,9 @@ const YieldCalculator = () => {
 
   return (
     <span>
-      <Typography variant="h5">yUSD Yield Calculator</Typography>
+      <Typography variant="h5">{tokenSymbol} Yield Calculator</Typography>
       <Typography>
-        The yield for yUSD changes if you plan on <i>buying</i> it as a
+        The yield for {tokenSymbol} changes if you plan on <i>buying</i> it as a
         borrower, looking for a stable yield or <i>selling</i> it as a lender,
         looking to gain levered exposure on your ETH.
       </Typography>
@@ -127,7 +127,7 @@ const YieldCalculator = () => {
                 onChange={(e) => setTokenPrice(e.target.value)}
                 variant="outlined"
                 inputProps={{ min: "0", max: "10", step: "0.01" }}
-                helperText={`Enter the price of yUSD in $`}
+                helperText={`${tokenSymbol} price in USD`}
                 InputLabelProps={{
                   shrink: true,
                 }}

--- a/features/yield/YieldCalculator.tsx
+++ b/features/yield/YieldCalculator.tsx
@@ -60,7 +60,8 @@ const YieldCalculator = () => {
 
     // `yieldPerUnit` = (FACE/yUSD_PX)^(1/(365/DAYS_TO_EXP)) - 1,
     // where FACE = $1. More details: https://www.bankrate.com/glossary/a/apy-annual-percentage-yield/
-    const yieldPerUnit = (1 - _tokenPrice) * (DAYS_PER_YEAR / _daysToExpiry);
+    const yieldPerUnit =
+      Math.pow(1 / _tokenPrice, 1 / (_daysToExpiry / DAYS_PER_YEAR)) - 1;
     const flipSign = _selectedUserMode === USER_MODE.BUY ? 1 : -1;
     return yieldPerUnit * flipSign;
   };


### PR DESCRIPTION
This PR fixes an issue in the yield calculator for renBTC. Before this PR, the balancer graphQL query expects the `tokensList` in the pools had the synth token USDC token address in an array. This works for `yUSD-SEP20` and `yUSD-OCT20`. However for `uUSDrBTC-OCT` this order has flipped around. To accommodate any direction, this PR modifies the `YIELD_TOKENS` object to store a string-array key-value object to store relevant balancer lookups with the correct token ordering.
