### PR TITLE
feat(liquidation-dialog): warn user if they are looking at a position that is not theirs

### DIFF
--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -474,14 +474,15 @@ const PositionActionsDialog = (props: DialogProps) => {
                           props.selectedSponsor?.toLowerCase() && (
                           <Box pt={2} pb={3}>
                             <Alert severity="warning">
-                              The sponsor of this position (
+                              Make sure you control the sponsor address{" "}
                               <a
                                 href={getEtherscanUrl(props.selectedSponsor)}
                                 target="_blank"
                               >
                                 {prettyAddress(props.selectedSponsor)}
-                              </a>
-                              ) does not match the connected wallet address.
+                              </a>{" "}
+                              before depositing. Otherwise, you will lose your
+                              deposit.
                             </Alert>
                           </Box>
                         )}

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -474,7 +474,7 @@ const PositionActionsDialog = (props: DialogProps) => {
                           props.selectedSponsor?.toLowerCase() && (
                           <Box pt={2} pb={3}>
                             <Alert severity="warning">
-                              The owner of this position (
+                              The sponsor of this position (
                               <a
                                 href={getEtherscanUrl(props.selectedSponsor)}
                                 target="_blank"

--- a/features/all-positions/PositionActionsDialog.tsx
+++ b/features/all-positions/PositionActionsDialog.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { utils } from "ethers";
 const { formatUnits: fromWei } = utils;
 import { useState, MouseEvent, useEffect } from "react";
+import Alert from "@material-ui/lab/Alert";
 
 import {
   Box,
@@ -29,6 +30,7 @@ import EmpContract from "../../containers/EmpContract";
 import Collateral from "../../containers/Collateral";
 import PriceFeed from "../../containers/PriceFeed";
 import Etherscan from "../../containers/Etherscan";
+import Connection from "../../containers/Connection";
 
 import { DOCS_MAP } from "../../utils/getDocLinks";
 import { toWeiSafe } from "../../utils/convertToWeiSafely";
@@ -96,6 +98,8 @@ const PositionActionsDialog = (props: DialogProps) => {
     setMaxAllowance: setMaxCollateralAllowance,
   } = Collateral.useContainer();
   const { activeSponsors } = EmpSponsors.useContainer();
+  const { address: connectedWalletAddress } = Connection.useContainer();
+
   const [tabIndex, setTabIndex] = useState<string>("deposit");
   const [collateralToDeposit, setCollateralToDeposit] = useState<string>("");
 
@@ -463,9 +467,24 @@ const PositionActionsDialog = (props: DialogProps) => {
                       <ToggleButton value="liquidate">liquidate</ToggleButton>
                     </ToggleButtonGroup>
                   </Box>
-                  <Box>
+                  <Box pt={2}>
                     {tabIndex === "deposit" && (
-                      <Box pt={2}>
+                      <Box>
+                        {connectedWalletAddress?.toLowerCase() !==
+                          props.selectedSponsor?.toLowerCase() && (
+                          <Box pt={2} pb={3}>
+                            <Alert severity="warning">
+                              The owner of this position (
+                              <a
+                                href={getEtherscanUrl(props.selectedSponsor)}
+                                target="_blank"
+                              >
+                                {prettyAddress(props.selectedSponsor)}
+                              </a>
+                              ) does not match the connected wallet address.
+                            </Alert>
+                          </Box>
+                        )}
                         <Typography>
                           <strong>
                             Deposit collateral into this sponsor's position


### PR DESCRIPTION
We have had users burnt from not realizing that they are interacting with a position that is not theirs. This PR places an alert if this is the case in the deposit screen.

![image](https://user-images.githubusercontent.com/12886084/92521746-08df1600-f21e-11ea-8c75-5d07132bdf55.png)
