### PR TITLE
fix(redeem): MAX button on Redeem page sets incorrectly

### DIFF
--- a/containers/Token.ts
+++ b/containers/Token.ts
@@ -21,6 +21,7 @@ function useToken() {
   const [decimals, setDecimals] = useState<number | null>(null);
   const [allowance, setAllowance] = useState<number | "Infinity" | null>(null);
   const [balance, setBalance] = useState<number | null>(null);
+  const [balanceBN, setBalanceBN] = useState<BigNumber | null>(null);
 
   const getTokenInfo = async () => {
     if (contract) {
@@ -44,6 +45,7 @@ function useToken() {
       setName(name);
       setDecimals(decimals);
       setBalance(balance);
+      setBalanceBN(balanceRaw);
       setAllowance(allowance);
     }
   };
@@ -64,6 +66,7 @@ function useToken() {
     setName(null);
     setDecimals(null);
     setBalance(null);
+    setBalanceBN(null);
     setAllowance(null);
     getTokenInfo();
   }, [contract]);
@@ -91,6 +94,7 @@ function useToken() {
     symbol,
     decimals,
     balance,
+    balanceBN,
     allowance,
     setMaxAllowance,
   };

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -47,6 +47,7 @@ const Redeem = () => {
     decimals: tokenDec,
     setMaxAllowance,
     balance: tokenBalance,
+    balanceBN: tokenBalanceBN,
   } = Token.useContainer();
   const { getEtherscanUrl } = Etherscan.useContainer();
 
@@ -60,6 +61,7 @@ const Redeem = () => {
     posCollString !== null &&
     minSponsorTokens !== null &&
     tokenBalance !== null &&
+    tokenBalanceBN !== null &&
     tokenDec !== null &&
     tokenSymbol !== null &&
     tokenAllowance !== null &&
@@ -121,8 +123,8 @@ const Redeem = () => {
 
     const setTokensToRedeemToMax = () => {
       // `tokenBalance` and `posTokens` might be incorrectly rounded,
-      // so we round them arbitrarily to the same precision to compare.
-      if (tokenBalance.toFixed(4) >= posTokens.toFixed(4)) {
+      // so we compare their raw BN's instead.
+      if (tokenBalanceBN.gte(toWeiSafe(posTokensString, tokenDec))) {
         setTokens(posTokensString);
       } else {
         setTokens(tokenBalance.toString());

--- a/features/manage-position/Redeem.tsx
+++ b/features/manage-position/Redeem.tsx
@@ -120,7 +120,9 @@ const Redeem = () => {
     };
 
     const setTokensToRedeemToMax = () => {
-      if (tokenBalance > posTokens) {
+      // `tokenBalance` and `posTokens` might be incorrectly rounded,
+      // so we round them arbitrarily to the same precision to compare.
+      if (tokenBalance.toFixed(4) >= posTokens.toFixed(4)) {
         setTokens(posTokensString);
       } else {
         setTokens(tokenBalance.toString());

--- a/utils/convertToWeiSafely.ts
+++ b/utils/convertToWeiSafely.ts
@@ -14,8 +14,15 @@ export function toWeiSafe(
   const precisionToUse = desiredPrecision
     ? desiredPrecision
     : DEFAULT_PRECISION;
-  return toWei(
-    Number(numberToConvertToWei).toFixed(precisionToUse),
-    precisionToUse
-  );
+
+  // Try converting just the raw string first to avoid unneccessary stripping of precision.
+  try {
+    return toWei(numberToConvertToWei, precisionToUse);
+  } catch (err) {
+    // This shouldn't throw an error, and if it does then its unexpected and we want to know about it.
+    return toWei(
+      Number(numberToConvertToWei).toFixed(precisionToUse),
+      precisionToUse
+    );
+  }
 }


### PR DESCRIPTION
This button is supposed to set the amount to redeem to either the user's balance or the total position debt, depending on which is larger.

However, the comparison is comparing two numbers that have had their precision potentially reduced, so we should be comparing the two numbers using the same precision.