### PR TITLE
improve(performance) & fix(farming calc): Remove unneccessary queries and fix farming calc fix

### DIFF
--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -302,7 +302,6 @@ const useBalancer = () => {
     usdPrice,
     shares,
     userShareFraction,
-    initializeTokenAddress,
     getPoolDataForToken,
     getTokenPrice,
   };

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -63,10 +63,6 @@ const useBalancer = () => {
     null
   );
 
-  // Because apollo caches results of queries, we will poll/refresh this query periodically.
-  // We set the poll interval to a very slow 5 seconds for now since the position states
-  // are not expected to change much.
-  // Source: https://www.apollographql.com/docs/react/data/queries/#polling
   const {
     loading: tokenPriceLoading,
     error: tokenPriceError,
@@ -75,14 +71,12 @@ const useBalancer = () => {
     skip: !selectedTokenAddress,
     context: { clientName: "BALANCER" },
     variables: { tokenId: selectedTokenAddress },
-    pollInterval: 5000,
   });
   const { loading: poolLoading, error: poolError, data: poolData } = useQuery(
     POOL(JSON.stringify(poolTokenList)),
     {
       skip: !poolTokenList,
       context: { clientName: "BALANCER" },
-      pollInterval: 5000,
     }
   );
 

--- a/containers/Balancer.ts
+++ b/containers/Balancer.ts
@@ -6,6 +6,7 @@ import { TOKENS, POOL } from "../apollo/balancer/queries";
 
 import Connection from "./Connection";
 import Token from "./Token";
+import { YIELD_TOKENS } from "../utils/yieldTokenList";
 
 interface PoolState {
   exitsCount: number;
@@ -37,35 +38,6 @@ interface yieldPair {
   [key: string]: string;
 }
 
-interface yieldToken {
-  [key: string]: yieldPair;
-}
-
-// The keys in this object are the synthetic token. the `token0` and `token1` are
-// the balancer pool key value pairs for the first and second token in the pool.
-const YIELD_TOKENS: yieldToken = {
-  "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5": {
-    token0: "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
-    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  }, // yUSDETH-SEP20
-  "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4": {
-    token0: "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4",
-    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  }, // yUSDETH-Oct20
-  "0x208d174775dc39fe18b1b374972f77ddec6c0f73": {
-    token0: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-    token1: "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
-  }, // uUSDrBTC-OCT
-  "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9": {
-    token0: "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9",
-    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  }, // uUSDwETH-DEC
-  "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce": {
-    token0: "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce",
-    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  }, // uUSDrBTC-DEC
-};
-
 const useBalancer = () => {
   const { address, block$ } = Connection.useContainer();
   const { address: tokenAddress } = Token.useContainer();
@@ -82,7 +54,6 @@ const useBalancer = () => {
     string | null
   >(null);
   const [poolTokenList, setPoolTokenList] = useState<string[] | null>(null);
-  const [isYieldToken, setIsYieldToken] = useState<boolean>(false);
 
   const [usdPrice, setUsdPrice] = useState<number | null>(null);
   const [poolAddress, setPoolAddress] = useState<string | null>(null);
@@ -121,7 +92,6 @@ const useBalancer = () => {
       const IS_YIELD_TOKEN = Object.keys(YIELD_TOKENS).includes(
         tokenAddress.toLowerCase()
       );
-      setIsYieldToken(IS_YIELD_TOKEN);
       if (IS_YIELD_TOKEN) {
         setSelectedTokenAddress(tokenAddress.toLowerCase());
         setPoolTokenList([
@@ -338,8 +308,7 @@ const useBalancer = () => {
     usdPrice,
     shares,
     userShareFraction,
-    isYieldToken,
-    YIELD_TOKENS,
+    initializeTokenAddress,
     getPoolDataForToken,
     getTokenPrice,
   };

--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -14,7 +14,6 @@ import { isPricefeedInvertedFromTokenSymbol } from "../utils/getOffchainPrice";
 
 import { useQuery } from "@apollo/client";
 import { EMP_DATA } from "../apollo/uma/queries";
-import { client } from "../apollo/client";
 
 // Interfaces for dApp state storage.
 interface SponsorPositionState {
@@ -72,14 +71,9 @@ const useEmpSponsors = () => {
   const { decimals: collDecs } = Collateral.useContainer();
   const { symbol: tokenSymbol } = Token.useContainer();
 
-  // Because apollo caches results of queries, we will poll/refresh this query periodically.
-  // We set the poll interval to a very slow 5 seconds for now since the position states
-  // are not expected to change much.
-  // Source: https://www.apollographql.com/docs/react/data/queries/#polling
   const subgraphToQuery = `UMA${network?.chainId.toString()}`;
   const { loading, error, data } = useQuery(EMP_DATA, {
     context: { clientName: subgraphToQuery },
-    pollInterval: 5000,
   });
 
   const getCollateralRatio = (

--- a/features/yield/FarmingCalculator.tsx
+++ b/features/yield/FarmingCalculator.tsx
@@ -6,6 +6,7 @@ import Balancer from "../../containers/Balancer";
 import Token from "../../containers/Token";
 
 import { getUmaPrice, getRenPrice } from "../../utils/getCoinGeckoTokenPrice";
+import { YIELD_TOKENS } from "../../utils/yieldTokenList";
 
 const FormInput = styled.div`
   margin-top: 20px;
@@ -42,7 +43,6 @@ const FarmingCalculator = () => {
   const {
     getTokenPrice,
     getPoolDataForToken,
-    YIELD_TOKENS,
     poolAddress,
   } = Balancer.useContainer();
   const { symbol: tokenSymbol, address } = Token.useContainer();
@@ -194,6 +194,8 @@ const FarmingCalculator = () => {
     }
     if (Object.keys(WEEKLY_UMA_REWARDS).includes(tokenAddress)) {
       setRewardToken(WEEKLY_UMA_REWARDS[tokenAddress]);
+    } else {
+      setRewardToken(null);
     }
 
     // Check if token should display roll information.

--- a/features/yield/FarmingCalculator.tsx
+++ b/features/yield/FarmingCalculator.tsx
@@ -137,13 +137,21 @@ const FarmingCalculator = () => {
         [key: string]: number;
       }
       const usdRewards: rewardTokenMap = {};
-      const tokenPrices: rewardTokenMap = {};
+
+      // Fetch token prices if not set already.
+      let tokenPrices: rewardTokenMap = rewardTokenPrices;
       for (let rewardObj of rewardToken) {
-        const _tokenPrice = await rewardObj.getPrice();
-        tokenPrices[rewardObj.token] = _tokenPrice;
+        let _tokenPrice;
+        if (!tokenPrices[rewardObj.token]) {
+          _tokenPrice = await rewardObj.getPrice();
+          tokenPrices[rewardObj.token] = _tokenPrice;
+        } else {
+          _tokenPrice = tokenPrices[rewardObj.token];
+        }
         const _rewards = rewardObj.count;
         const _usdYield = _tokenPrice * _rewards;
         usdPaidPerWeek += _usdYield;
+
         usdRewards[rewardObj.token] = _usdYield;
       }
 

--- a/features/yield/Yield.tsx
+++ b/features/yield/Yield.tsx
@@ -8,8 +8,9 @@ import BalancerData from "./BalancerData";
 import FarmingCalculator from "./FarmingCalculator";
 
 import Connection from "../../containers/Connection";
-import Balancer from "../../containers/Balancer";
 import Token from "../../containers/Token";
+
+import { YIELD_TOKENS } from "../../utils/yieldTokenList";
 
 const OutlinedContainer = styled.div`
   padding: 1rem;
@@ -18,8 +19,12 @@ const OutlinedContainer = styled.div`
 
 const Yield = () => {
   const { network } = Connection.useContainer();
-  const { isYieldToken } = Balancer.useContainer();
+  const { address: tokenAddress } = Token.useContainer();
   const { symbol: tokenSymbol } = Token.useContainer();
+
+  const isYieldToken =
+    tokenAddress &&
+    Object.keys(YIELD_TOKENS).includes(tokenAddress.toLowerCase());
 
   const [dialogTabIndex, setDialogTabIndex] = useState<string>(
     "farming-calculator"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,8 +24,10 @@ import Weth from "../features/weth/Weth";
 import Yield from "../features/yield/Yield";
 
 import Collateral from "../containers/Collateral";
+import Token from "../containers/Token";
 import WethContract from "../containers/WethContract";
-import Balancer from "../containers/Balancer";
+
+import { YIELD_TOKENS } from "../utils/yieldTokenList";
 
 import GitHubIcon from "@material-ui/icons/GitHub";
 import TwitterIcon from "@material-ui/icons/Twitter";
@@ -50,8 +52,12 @@ export default function Index() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { address: collAddress } = Collateral.useContainer();
+  const { address: tokenAddress } = Token.useContainer();
   const { contract: weth } = WethContract.useContainer();
-  const { isYieldToken } = Balancer.useContainer();
+
+  const isYieldToken =
+    tokenAddress &&
+    Object.keys(YIELD_TOKENS).includes(tokenAddress.toLowerCase());
 
   const options = ["General Info", "Manage Position", "All Positions"];
 

--- a/utils/yieldTokenList.ts
+++ b/utils/yieldTokenList.ts
@@ -1,0 +1,32 @@
+// The keys in this object are the synthetic token. the `token0` and `token1` are
+// the balancer pool key value pairs for the first and second token in the pool.
+interface yieldPair {
+  [key: string]: string;
+}
+
+interface yieldToken {
+  [key: string]: yieldPair;
+}
+
+export const YIELD_TOKENS: yieldToken = {
+  "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5": {
+    token0: "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // yUSDETH-SEP20
+  "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4": {
+    token0: "0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // yUSDETH-Oct20
+  "0x208d174775dc39fe18b1b374972f77ddec6c0f73": {
+    token0: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    token1: "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
+  }, // uUSDrBTC-OCT
+  "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9": {
+    token0: "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // uUSDwETH-DEC
+  "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce": {
+    token0: "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce",
+    token1: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  }, // uUSDrBTC-DEC
+};


### PR DESCRIPTION
- Farming calc page was not resetting `rewardToken = null` when the selected EMP changes, which falsely displayed the Farming calc for non eligible tokens
- CoinGeckoAPI was getting pinged constantly (> 100 a second at least), I added a check to see if we previously loaded token price data
- GraphQL queries were refreshing every few seconds in the background, I removed this polling functionality

Fixes #168 
Fixes #167 