### PR TITLE
improve(create): Prevent rounding errors that unintentionally break the GCR restraint on-chain

### DIFF
--- a/features/manage-position/Create.tsx
+++ b/features/manage-position/Create.tsx
@@ -96,7 +96,7 @@ const Create = () => {
       // We want to round down the number for better UI display, but we don't actually want the collateral
       // amount to round down since we want the minimum amount of collateral to pass the GCR constraint. So,
       // we'll add a tiny amount of collateral to avoid accidentally rounding too low.
-      setCollateral((minBackingCollateral + 0.00005).toFixed(4));
+      setCollateral(Math.ceil(minBackingCollateral).toString());
     }
   };
 
@@ -141,7 +141,7 @@ const Create = () => {
     const maxTokensToCreate = _gcr > 0 ? collateral / _gcr - startingTokens : 0;
     // Unlike the min collateral, we're ok if we round down the tokens slightly as round down
     // can only increase the position's CR and maintain it above the GCR constraint.
-    setTokens((maxTokensToCreate - 0.0001).toFixed(4));
+    setTokens(Math.floor(maxTokensToCreate).toString());
   };
 
   const setTokensToMax = (


### PR DESCRIPTION
Conservatively CEIL and FLOOR the [min amount of backing collateral]/[max amount of tokens] when calling create. This trades off perfect capital efficiency for UX. We want to eliminate this oft-repeated user error where an obscure "gas required exceeeds allowance" error message occurs, which just indicates that the transaction is failing on-chain, because the front-end is incorrectly rounding numbers

![Screen Shot 2020-09-27 at 16 56 21](https://user-images.githubusercontent.com/9457025/94375587-c30dc300-00e2-11eb-9ff5-88ebd0848b9d.png)
