### PR TITLE
improve(expiry): Should check for `expiryPrice` on EMP contract in addition to DVM resolved price

### DIFF
--- a/containers/EmpState.ts
+++ b/containers/EmpState.ts
@@ -25,6 +25,7 @@ interface ContractState {
   isExpired: boolean | null;
   contractState: number | null;
   finderAddress: string | null;
+  expiryPrice: BigNumber | null;
 }
 
 const initState = {
@@ -47,6 +48,7 @@ const initState = {
   isExpired: null,
   contractState: null,
   finderAddress: null,
+  expiryPrice: null,
 };
 
 const useContractState = () => {
@@ -81,6 +83,7 @@ const useContractState = () => {
         emp.getCurrentTime(),
         emp.contractState(),
         emp.finder(),
+        emp.expiryPrice(),
       ]);
 
       const newState: ContractState = {
@@ -103,6 +106,7 @@ const useContractState = () => {
         isExpired: Number(res[15]) >= Number(res[0]),
         contractState: Number(res[16]),
         finderAddress: res[17] as string, // address
+        expiryPrice: res[18] as BigNumber,
       };
 
       setState(newState);

--- a/features/manage-position/SettleExpired.tsx
+++ b/features/manage-position/SettleExpired.tsx
@@ -90,7 +90,6 @@ const SettleExpired = () => {
     const resolvedPrice = dvmResolvedPrice
       ? dvmResolvedPrice
       : parseFloat(fromWei(expiryPrice.toString(), collDec)); // DVM identifier should have same precision as collateral.
-    // It's possible that the EMP has a price available even if resolvedPrice is 0
     const hasEmpPrice = resolvedPrice !== 0;
 
     // Error conditions for calling settle expired:

--- a/features/yield/Yield.tsx
+++ b/features/yield/Yield.tsx
@@ -1,17 +1,14 @@
+import { useState, MouseEvent } from "react";
 import { Box, Typography } from "@material-ui/core";
+import { ToggleButton, ToggleButtonGroup } from "@material-ui/lab";
 import styled from "styled-components";
+
+import YieldCalculator from "./YieldCalculator";
+import BalancerData from "./BalancerData";
+import FarmingCalculator from "./FarmingCalculator";
 
 import Connection from "../../containers/Connection";
 import Token from "../../containers/Token";
-import Balancer from "../../containers/Balancer";
-
-import { getExchangeInfo } from "../../utils/getExchangeLinks";
-
-const Important = styled(Typography)`
-  color: red;
-  background: black;
-  display: inline-block;
-`;
 
 import { YIELD_TOKENS } from "../../constants/yieldTokens";
 
@@ -20,23 +17,26 @@ const OutlinedContainer = styled.div`
   border: 1px solid #434343;
 `;
 
-const Link = styled.a`
-  font-size: 14px;
-`;
-
 const Yield = () => {
   const { network } = Connection.useContainer();
-  const { address: tokenAddress, symbol: tokenSymbol } = Token.useContainer();
-  const { poolAddress } = Balancer.useContainer();
+  const { address: tokenAddress } = Token.useContainer();
+  const { symbol: tokenSymbol } = Token.useContainer();
 
   const isYieldToken =
     tokenAddress &&
     Object.keys(YIELD_TOKENS).includes(tokenAddress.toLowerCase());
 
-  const balancerPoolUrl = `https://pools.balancer.exchange/#/pool/${poolAddress}`;
-  const exchangeInfo = getExchangeInfo(tokenSymbol);
-  const getExchangeLinkToken = exchangeInfo?.getExchangeUrl(tokenAddress);
-  const exchangeName = exchangeInfo?.name;
+  const [dialogTabIndex, setDialogTabIndex] = useState<string>(
+    "farming-calculator"
+  );
+  const handleAlignment = (
+    event: MouseEvent<HTMLElement>,
+    newAlignment: string
+  ) => {
+    if (newAlignment) {
+      setDialogTabIndex(newAlignment);
+    }
+  };
 
   if (network === null || network.chainId !== 1 || !isYieldToken) {
     return (
@@ -84,60 +84,35 @@ const Yield = () => {
         </Box>
         <Box pb={2}>
           <OutlinedContainer>
-            <Important>Update 09/27/20</Important>
-            <br></br>
-            <br></br>
-            <Typography>
-              We fetch Balancer pool data from the Balancer subgraph API, which
-              is currently returning inaccurate information. Instead of
-              displaying inaccurate data, we redirect you to the Balancer pool
-              and exchange interfaces where you can access accurate on-chain
-              information. This fix has no ETA yet, but we will revert back to
-              the old display as soon as the data is accurate. Apologies for the
-              inconvenience!
-            </Typography>
-            <br></br>
-            <Typography>
-              After 09/27/20 @ 23:00:00 UTC, only the uUSDrenBTC and uUSDwETH
-              contracts will be eligible for liquidity mining. 10,000 UMA and
-              25,000 UMA, respectively, are granted pro-rata (based on
-              continuous snapshots) to LP's in the uUSDwBTC-USDC and uUSDwETH
-              Balancer pools.
-            </Typography>
-            <br></br>
-            <br></br>
-            <Link
-              href={balancerPoolUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Balancer Pool Link
-            </Link>{" "}
-            ← Go here to add & remove liquidity
-            <br></br>
-            <br></br>
-            <Link
-              href={getExchangeLinkToken}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {exchangeName} Exchange Link
-            </Link>{" "}
-            ← Go here to check the {tokenSymbol} exchange rate
-            <br></br>
-            <br></br>
-            <Typography>
-              <strong>APY</strong>: To approximate your weekly returns, you can
-              divide the $ amount of UMA rewarded for a pool per week by the $
-              amount of pooled liquidity. For example, if the pool size is $10
-              million, the UMA-USD price is $10, and the reward is 25,000
-              UMA/week, then the return for each $1 supplied to the pool is:{" "}
-              <strong>
-                ($10 * 25,000 / $10 million) * 100 = 2.5% weekly return
-              </strong>
-            </Typography>
+            <BalancerData />
           </OutlinedContainer>
         </Box>
+        <Box py={1} textAlign="center">
+          <ToggleButtonGroup
+            value={dialogTabIndex}
+            exclusive
+            onChange={handleAlignment}
+          >
+            <ToggleButton value="farming-calculator">
+              Liquidity Mining
+            </ToggleButton>
+            <ToggleButton value="yusd-calculator">yield dollar</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        {dialogTabIndex === "farming-calculator" && (
+          <Box py={2}>
+            <OutlinedContainer>
+              <FarmingCalculator />
+            </OutlinedContainer>
+          </Box>
+        )}
+        {dialogTabIndex === "yusd-calculator" && (
+          <Box py={2}>
+            <OutlinedContainer>
+              <YieldCalculator />
+            </OutlinedContainer>
+          </Box>
+        )}
       </Box>
     );
   }


### PR DESCRIPTION
It is possible that DVM has not resolved a price but EMP has an `expiryPrice()` (if the DVM has been upgraded since the EMP's expiry), and its possible that an EMP has no `expiryPrice()` but the DVM has resolved a price (right after the DVM has finished its reveal round but before anyone has attempted to `settle()` on the EMP)