### PR TITLE
feat&fix(liquidation-liveness) add liquidation liveness to General Info and fix liquidation table

### DIFF
--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -133,7 +133,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
 
     const liquidationTimeRemaining =
       Number(liquidatedPosition.liquidationTimestamp) +
-      Number(withdrawalLiveness) -
+      Number(liquidationLiveness) -
       Number(currentTime);
 
     const pendingLiquidationTimeString =

--- a/features/contract-state/DisputeParams.tsx
+++ b/features/contract-state/DisputeParams.tsx
@@ -32,6 +32,7 @@ const DisputeParams = () => {
     disputerDisputeRewardPct,
     sponsorDisputeRewardPct,
     withdrawalLiveness,
+    liquidationLiveness,
   } = empState;
 
   const { dvmState } = DvmState.useContainer();
@@ -41,6 +42,9 @@ const DisputeParams = () => {
   const withdrawalLivenessInMinutes = (Number(withdrawalLiveness) / 60).toFixed(
     2
   );
+  const liquidationLivenessInMinutes = (
+    Number(liquidationLiveness) / 60
+  ).toFixed(2);
 
   return (
     <Box>
@@ -96,6 +100,24 @@ const DisputeParams = () => {
           title={`To withdraw past the global collateralization ratio, you will need to wait a liveness period before completing your withdrawal.`}
         >
           <span>{withdrawalLivenessInMinutes}</span>
+        </Tooltip>
+      </Status>
+      <Status>
+        <Label>
+          Liquidation liveness in mins (
+          <Link
+            href={DOCS_MAP.FINAL_FEE}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Docs
+          </Link>
+          ){`: `}
+        </Label>
+        <Tooltip
+          title={`After a liquidation is submitted the position enters into a liveness period during which the liquidation can be disputed if invalid.`}
+        >
+          <span>{liquidationLivenessInMinutes}</span>
         </Tooltip>
       </Status>
     </Box>


### PR DESCRIPTION
This PR does two things:
1) The liquidation liveness is not shown on the "General Info" table. Normally, this is the same as withdrawal liveness but this is not strictly the case. This PR adds this information.

After this PR the dispute params looks as follows.
![image](https://user-images.githubusercontent.com/12886084/94652551-80263800-02fa-11eb-9104-be62752b35d5.png)


2) there was an error in the liquidations table, as documented in #185 where the `LiquidationActionDialog` incorrectly displayed the liquidation time remaining due to incorrect variable usage.

close #185 

