### PR TITLE
fix(syling): padding on home page on to deal with so many tokens 🤑

### DIFF
--- a/features/contract-state/Totals.tsx
+++ b/features/contract-state/Totals.tsx
@@ -11,7 +11,8 @@ import { getExchangeInfo } from "../../utils/getExchangeLinks";
 
 const DataBox = styled(Box)`
   border: 1px solid #434343;
-  padding: 1rem 2rem;
+  padding: 1rem 1rem;
+  margin: 1rem 1rem;
 `;
 
 const Label = styled.div`
@@ -129,7 +130,7 @@ const Totals = () => {
     addTokenToMetamask: any = null
   ) {
     return (
-      <>
+      <Grid container spacing={0}>
         <Grid item md={6} xs={12}>
           <DataBox>
             <Typography variant="h4">
@@ -200,7 +201,7 @@ const Totals = () => {
             </LinksContainer>
           </DataBox>
         </Grid>
-      </>
+      </Grid>
     );
   }
 };


### PR DESCRIPTION
before this PR:
![image](https://user-images.githubusercontent.com/12886084/96180329-8fc89200-0f32-11eb-8512-6dc98254dd72.png)


After this PR:
![image](https://user-images.githubusercontent.com/12886084/96180353-97883680-0f32-11eb-85e8-2fa525fe1fdd.png)

And still scales as expected on mobile:
![image](https://user-images.githubusercontent.com/12886084/96180385-a66ee900-0f32-11eb-8ad6-57a604560972.png)

