### PR TITLE
fix(farming-calculator): Fix how dev mining rewards are calculated mid-roll + other small fixes

### DIFF
--- a/constants/rewards.ts
+++ b/constants/rewards.ts
@@ -30,6 +30,7 @@ export const WEEKLY_UMA_REWARDS: { [key: string]: any[] } = {
       count: 25000,
       getPrice: getUmaPrice,
       startDate: Date.UTC(2020, 8, 23, 23, 0, 0, 0),
+      endDate: Date.UTC(2020, 11, 28, 23, 0, 0, 0),
     },
   ], // uUSDwETH-DEC
   "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce": [
@@ -38,6 +39,7 @@ export const WEEKLY_UMA_REWARDS: { [key: string]: any[] } = {
       count: 10000,
       getPrice: getUmaPrice,
       startDate: Date.UTC(2020, 8, 23, 23, 0, 0, 0),
+      endDate: Date.UTC(2020, 11, 28, 23, 0, 0, 0),
     },
     {
       token: "REN",
@@ -50,17 +52,17 @@ export const WEEKLY_UMA_REWARDS: { [key: string]: any[] } = {
   "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8": [
     {
       token: "UMA",
-      count: 15000, // This is an approximation based on expected dev mining allocation
+      count: 25000,
       getPrice: getUmaPrice,
-      startDate: Date.UTC(2020, 12, 25, 23, 0, 0, 0),
+      startDate: Date.UTC(2020, 11, 25, 23, 0, 0, 0),
     },
   ], // YD-ETH-MAR21
   "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d": [
     {
       token: "UMA",
-      count: 10000, // This is an approximation based on expected dev mining allocation
+      count: 10000,
       getPrice: getUmaPrice,
-      startDate: Date.UTC(2020, 12, 25, 23, 0, 0, 0),
+      startDate: Date.UTC(2020, 11, 25, 23, 0, 0, 0),
     },
   ], // YD-BTC-MAR21
 };
@@ -68,17 +70,19 @@ export const WEEKLY_UMA_REWARDS: { [key: string]: any[] } = {
 // Key is roll from token address.
 export const ROLL_REWARDS_SCHEDULE: { [key: string]: any } = {
   "0xd16c79c8a39d44b2f3eb45d2019cd6a42b03e2a9": {
+    rollFromEmpAddress: "0x3605Ec11BA7bD208501cbb24cd890bC58D2dbA56",
     rollFromTokenName: "uUSDwETH-DEC",
     rollToTokenName: "YD-ETH-MAR21",
     rollToToken: "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
-    rollStartDate: Date.UTC(2020, 12, 25, 23, 0, 0, 0),
-    rollDate: Date.UTC(2020, 12, 28, 23, 0, 0, 0),
+    rollStartDate: Date.UTC(2020, 11, 25, 23, 0, 0, 0),
+    rollDate: Date.UTC(2020, 11, 28, 23, 0, 0, 0),
   }, // uUSDwETH-DEC --> YD-ETH-MAR21
   "0xf06ddacf71e2992e2122a1a0168c6967afdf63ce": {
+    rollFromEmpAddress: "0xaBBee9fC7a882499162323EEB7BF6614193312e3",
     rollFromTokenName: "uUSDrBTC-DEC",
     rollToTokenName: "YD-BTC-MAR21",
     rollToToken: "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
-    rollStartDate: Date.UTC(2020, 12, 25, 23, 0, 0, 0),
-    rollDate: Date.UTC(2020, 12, 28, 23, 0, 0, 0),
+    rollStartDate: Date.UTC(2020, 11, 25, 23, 0, 0, 0),
+    rollDate: Date.UTC(2020, 11, 28, 23, 0, 0, 0),
   }, // uUSDrBTC-DEC --> YD-BTC-MAR21
 };

--- a/features/yield/FarmingCalculator.tsx
+++ b/features/yield/FarmingCalculator.tsx
@@ -189,14 +189,24 @@ const FarmingCalculator = () => {
     }
     if (devMiningRewards == null || empAddress == null) return;
     if (
+      rollFromTokenObj &&
       Object.keys(WEEKLY_UMA_REWARDS).includes(tokenAddress) &&
       devMiningRewards.has(empAddress)
     ) {
       // Strip out rewards that have expired or have not started yet.
       const allRewards = WEEKLY_UMA_REWARDS[tokenAddress];
-      // hardcoding LM rewards to half dev rewards. Probably should be parameterized
-      const liquidityRewards =
-        parseFloat(devMiningRewards.get(empAddress) || "0") / 2;
+      // First, determine which EMP address is receiving dev rewards. If roll has concluded,
+      // then use the current EMP address, other use the rollFromToken's EMP address.
+      let liquidityRewards;
+      if (isRolled) {
+        liquidityRewards = parseFloat(devMiningRewards.get(empAddress) || "0");
+      } else {
+        liquidityRewards = parseFloat(
+          devMiningRewards.get(rollFromTokenObj.rollFromEmpAddress) || "0"
+        );
+      }
+      // Hardcoding LM rewards to half of dev rewards; this should ideally be parameterized.
+      liquidityRewards /= 2;
       const filteredRewards = [];
       for (let i = 0; i < allRewards.length; i++) {
         const reward = allRewards[i];


### PR DESCRIPTION


- The month in `Date.UTC()` is supposed to be zero-indexed
- The farming calc hard-codes liquidity rewards to 1/2 of dev mining rewards, but mistakenly computes dev mining rewards for the current EMP address even when the roll is currently undergoing. In these situations, the dev mining rewards should be computed for the EMP from which the roll is occurring (i.e. the "old" EMP)
- Adds an end-date to DEC contracts so that they stop showing rewards post-roll.

Overall, this entire liquidity mining calculator clearly needs a makeover.