### PR TITLE
fix(calculators): update EMP valuation to use synthetic, and import active emp list

### DIFF
--- a/containers/DevMining.ts
+++ b/containers/DevMining.ts
@@ -9,26 +9,34 @@ import uma from "@studydefi/money-legos/uma";
 
 import Connection from "./Connection";
 
-export const defaultEmpWhitelist = [
-  "0xaBBee9fC7a882499162323EEB7BF6614193312e3",
-  "0x3605Ec11BA7bD208501cbb24cd890bC58D2dbA56",
-  "0x3a93E863cb3adc5910E6cea4d51f132E8666654F",
-  "0xE4256C47a3b27a969F25de8BEf44eCA5F2552bD5",
-  "0x1c3f1A342c8D9591D9759220d114C685FD1cF6b8",
-];
-
 export const defaultTotalRewards = 50000;
+const empStatusUrl =
+  "https://raw.githubusercontent.com/UMAprotocol/protocol/master/packages/affiliates/payouts/devmining-status.json";
 
-const useDevMiningCalculator = ({
-  totalRewards = defaultTotalRewards,
-  empWhitelist = defaultEmpWhitelist,
-} = {}) => {
+const useDevMiningCalculator = () => {
   const { provider } = Connection.useContainer();
   const [devMiningRewards, setRewards] = useState<Map<string, string> | null>();
   const [devMiningCalculator, setCalculator] = useState<any | null>();
+  const [empWhitelist, setEmpWhitelist] = useState<string[]>();
+  const [totalRewards, setTotalRewards] = useState<number>(defaultTotalRewards);
+
+  // pull latest whitelist
+  useEffect(() => {
+    fetch(empStatusUrl)
+      .then((response) => response.json())
+      .then((result) => {
+        setEmpWhitelist(result.empWhitelist);
+        setTotalRewards(result.totalReward);
+      })
+      .catch((err) => {
+        console.error("Error fetching Affiliates status", err);
+      });
+  }, []);
 
   useEffect(() => {
     if (provider == null) return;
+    if (empWhitelist == null) return;
+    if (totalRewards == null) return;
     const devMiningCalculator = DevMiningCalculator({
       ethers,
       getPrice: getSimplePriceByContract,

--- a/utils/calculators.ts
+++ b/utils/calculators.ts
@@ -50,16 +50,23 @@ export function DevMiningCalculator({
   const { parseEther } = utils;
   async function getEmpInfo(address: string, toCurrency = "usd") {
     const emp = new ethers.Contract(address, empAbi, provider);
-    const collateralAddress = await emp.collateralCurrency();
-    const erc20 = new ethers.Contract(collateralAddress, erc20Abi, provider);
-    const size = (await emp.rawTotalPositionCollateral()).toString();
-    const price = await getPrice(collateralAddress, toCurrency);
+    const tokenAddress = await emp.tokenCurrency();
+    const erc20 = new ethers.Contract(tokenAddress, erc20Abi, provider);
+    const size = (await emp.totalTokensOutstanding()).toString();
+    let price = 1;
+    try {
+      // we try to get a price, or fallback to 1 dollar. this will not work in all situations.
+      // better APR calculator coming soon.
+      price = await getPrice(tokenAddress, toCurrency);
+    } catch (err) {
+      console.error("Unable to get a price, falling back to $1", err);
+    }
     const decimals = await erc20.decimals();
 
     return {
       address,
       toCurrency,
-      collateralAddress,
+      tokenAddress,
       size,
       price,
       decimals,

--- a/utils/calculators.ts
+++ b/utils/calculators.ts
@@ -59,7 +59,8 @@ export function DevMiningCalculator({
       // better APR calculator coming soon.
       price = await getPrice(tokenAddress, toCurrency);
     } catch (err) {
-      console.error("Unable to get a price, falling back to $1", err);
+      // Dont show error for now
+      // console.error("Unable to get a price, falling back to $1", err);
     }
     const decimals = await erc20.decimals();
 


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Motivation #202 
This makes 2 major changes to EMP calculation:
- DevMining container now imports the active emplist from our github which @smb2796 and I maintain
- Previous EMP valuation was based off of total collateral locked. This changes it to synthetic minted, and attempts to get a price from coingecko, otherwise fallsback to 1 dollar, which most synthetics are. 

This produces much better results and are very close to this weeks payouts:
- yd eth estimates 7,886.682  vs [payout ](https://github.com/UMAprotocol/protocol/pull/2499)of 7080 
- yd btc estimates 8,681.799 vs [payout ](https://github.com/UMAprotocol/protocol/pull/2500)of 9067 

Closes #202