### PR TITLE
fix(emp-tools): change cors proxy and cleanup other requests

### DIFF
--- a/utils/calculators.ts
+++ b/utils/calculators.ts
@@ -51,8 +51,6 @@ export function DevMiningCalculator({
   async function getEmpInfo(address: string, toCurrency = "usd") {
     const emp = new ethers.Contract(address, empAbi, provider);
     const tokenAddress = await emp.tokenCurrency();
-    const erc20 = new ethers.Contract(tokenAddress, erc20Abi, provider);
-    const size = (await emp.totalTokensOutstanding()).toString();
     let price = 1;
     try {
       // we try to get a price, or fallback to 1 dollar. this will not work in all situations.
@@ -62,7 +60,9 @@ export function DevMiningCalculator({
       // Dont show error for now
       // console.error("Unable to get a price, falling back to $1", err);
     }
+    const erc20 = new ethers.Contract(tokenAddress, erc20Abi, provider);
     const decimals = await erc20.decimals();
+    const size = (await emp.totalTokensOutstanding()).toString();
 
     return {
       address,

--- a/utils/getCoinGeckoTokenPrice.ts
+++ b/utils/getCoinGeckoTokenPrice.ts
@@ -3,17 +3,15 @@
 
 // so this can be tested outside browser
 import fetch from "isomorphic-fetch";
+const fetchOptions = {
+  // currently no options needed, previously we were setting content type and accept.
+};
 
 export async function getUmaPrice() {
   const query =
     "https://api.coingecko.com/api/v3/simple/price?ids=uma&vs_currencies=usd";
 
-  const response = await fetch(query, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-  });
+  const response = await fetch(query, fetchOptions);
 
   let priceResponse = await response.json();
   return priceResponse.uma.usd;
@@ -23,12 +21,7 @@ export async function getRenPrice() {
   const query =
     "https://api.coingecko.com/api/v3/simple/price?ids=republic-protocol&vs_currencies=usd";
 
-  const response = await fetch(query, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-  });
+  const response = await fetch(query, fetchOptions);
 
   let priceResponse = await response.json();
   return priceResponse["republic-protocol"].usd;
@@ -39,24 +32,14 @@ export async function getSimplePrice(
   toCurrency: string = "usd"
 ) {
   const query = `https://api.coingecko.com/api/v3/simple/price?ids=${fromCurrency}&vs_currencies=${toCurrency}`;
-  const response = await fetch(query, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-  });
+  const response = await fetch(query, fetchOptions);
   let priceResponse = await response.json();
   return priceResponse[fromCurrency][toCurrency];
 }
 
 export async function getContractInfo(address: string) {
   const query = `https://api.coingecko.com/api/v3/coins/ethereum/contract/${address}`;
-  const response = await fetch(query, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-  });
+  const response = await fetch(query, fetchOptions);
   const result = await response.json();
   if (result.error) throw new Error(result.error);
   return result;

--- a/utils/getCoinGeckoTokenPrice.ts
+++ b/utils/getCoinGeckoTokenPrice.ts
@@ -4,7 +4,10 @@
 // so this can be tested outside browser
 import fetch from "isomorphic-fetch";
 const fetchOptions = {
-  // currently no options needed, previously we were setting content type and accept.
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
 };
 
 export async function getUmaPrice() {

--- a/utils/getOffchainPrice.ts
+++ b/utils/getOffchainPrice.ts
@@ -36,9 +36,12 @@ function stripProtocol(url: string) {
 }
 
 // Small helper to wrap a url in cors proxy.
-function proxyUrl(
+export function proxyUrl(
   url: string,
-  proxy = "https://us-central1-uma-protocol.cloudfunctions.net/cors-proxy"
+  // This env can be set with a .env file. It has to be prefixed with NEXT_PUBLIC_ to be available in browser
+  // This has a default set for now until we can get prod env var in.
+  proxy = process.env.NEXT_PUBLIC_CORS_PROXY_URL ||
+    "https://us-central1-uma-protocol.cloudfunctions.net/cors-proxy"
 ) {
   return [proxy, stripProtocol(url)].join("/");
 }

--- a/utils/getOffchainPrice.ts
+++ b/utils/getOffchainPrice.ts
@@ -30,6 +30,19 @@ function _getBitstampPriceFromJSON(jsonData: any) {
   return Number(jsonData.last);
 }
 
+// This is needed because our new cors proxy wont forward http or https. We really only use https.
+function stripProtocol(url: string) {
+  return url.replace("https://", "");
+}
+
+// Small helper to wrap a url in cors proxy.
+function proxyUrl(
+  url: string,
+  proxy = "https://us-central1-uma-protocol.cloudfunctions.net/cors-proxy"
+) {
+  return [proxy, stripProtocol(url)].join("/");
+}
+
 // This function returns a type predicate that we can use to filter prices from a (number | null)[] into a number[],
 // source: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
 function isValidPrice<Price>(value: Price | null): value is Price {
@@ -59,9 +72,9 @@ export const PRICEFEED_PARAMS: PricefeedParamsMap = {
   usdbtc: {
     invertedPrice: true,
     source: [
+      proxyUrl("https://www.bitstamp.net/api/v2/ticker/btcusd"),
       "https://api.binance.com/api/v3/avgPrice?symbol=BTCUSDT",
       "https://api.pro.coinbase.com/products/BTC-USD/trades?limit=1",
-      "https://cors-anywhere.herokuapp.com/https://www.bitstamp.net/api/v2/ticker/btcusd",
     ],
   },
 };


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

motivation #205 

Simply adds new cors proxy wrapper to bitstamp url. Adds as helper function in case we need to do this for other urls as well. 
Also updates coingecko calls to remove uncessessary header info, did not run into issues after this change, but verify if you can. 

fixes #205 
