### PR TITLE
fix(emp-tools): improve dev mining calc by falling back to collateral value if no token value

### DIFF
--- a/utils/calculators.test.ts
+++ b/utils/calculators.test.ts
@@ -86,9 +86,12 @@ test("DevMiningCalculator", async () => {
   });
   for (let contract of empWhitelist) {
     const result = await dmc.utils.getEmpInfo(contract);
-    expect(result.size).toBeTruthy();
-    expect(result.price).toBeTruthy();
-    expect(result.decimals).toBeTruthy();
+    expect(result.tokenCount).toBeTruthy();
+    expect(result.tokenPrice).toBeTruthy();
+    expect(result.collateralCount).toBeTruthy();
+    expect(result.collateralPrice).toBeTruthy();
+    expect(result.tokenDecimals).toBeTruthy();
+    expect(result.collateralDecimals).toBeTruthy();
     const value = dmc.utils.calculateEmpValue(result);
     expect(value).toBeTruthy();
   }


### PR DESCRIPTION
motivation #207
Previous calculation would fallback to 1 doller per token if a token price wasnt available. This caused a problem for some contracts where tokens are worth much more than 1 dollar. This now falls back to the value of the collateral locked in the emp and divides it by the collateralization ratio to estimate token minted. This could lead to large over estimation in some cases.

New Estimations:
![image](https://user-images.githubusercontent.com/4429761/108393491-b7ca4980-71e1-11eb-93b6-580cd3730282.png)

Previous week dev mining calcs:
```
    "0x3a93E863cb3adc5910E6cea4d51f132E8666654F": "191.374666273330978411",
    "0xaB3Aa2768Ba6c5876B2552a6F9b70E54aa256175": "4.525277475441628788",
    "0x1c3f1A342c8D9591D9759220d114C685FD1cF6b8": "14733.426577007680355462",
    "0xE4256C47a3b27a969F25de8BEf44eCA5F2552bD5": "17180.933058155691222569",
    "0xeAddB6AD65dcA45aC3bB32f88324897270DA0387": "4958.189487960342398192",
    "0xf215778F3a5e7Ab6A832e71d87267Dd9a9aB0037": "4697.082082416490736477",
    "0x267D46e71764ABaa5a0dD45260f95D9c8d5b8195": "11.3622028321626397",
    "0x2862A798B3DeFc1C24b9c0d241BEaF044C45E585": "910.092099957907146767",
    "0xd81028a6fbAAaf604316F330b20D24bFbFd14478": "87.903599287646920179",
    "0x7c4090170aeADD54B1a0DbAC2C8D08719220A435": "4617.123446402752465178",
    "0xaD3cceebeFfCdC3576dE56811d0A6D164BF9A5A1": "2241.799376577696154943",
    "0xC843538d70ee5d28C5A80A75bb94C28925bB1cf2": "169.758882095508819401",
    "0xeFA41F506EAA5c24666d4eE40888bA18FA60a1c7": "196.429243557347897904"
```

Generally should be a bit better than before, will slightly underestimate y-btc and y-eth now since the zelda contracts get slightly over estimated. 

fixes #207