### PR TITLE
patch(apollo): Change subgraph URL

### DIFF
--- a/apollo/client.ts
+++ b/apollo/client.ts
@@ -10,7 +10,7 @@ const umaLinkKovan = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma-kovan",
 });
 const umaLinkMainnet = new HttpLink({
-  uri: "https://api.thegraph.com/subgraphs/name/protofire/uma",
+  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma",
 });
 const balancerLink = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer",


### PR DESCRIPTION
protofire/uma subgraph is unsynced, uma-protocol/uma synced as of yesterday after patched a bug on mainnet.