### PR TITLE
 feat: add perpetual info boxes, clean up non working components

### DIFF
--- a/apollo/uniswap/queries.ts
+++ b/apollo/uniswap/queries.ts
@@ -1,8 +1,28 @@
+import assert from "assert";
 import { gql } from "@apollo/client";
 
-export const PAIR = gql`
-  query pair($token0: String!, $token1: String!) {
+export const FindPairByTokens = gql`
+  query findPairByTokens($token0: String!, $token1: String!) {
     pairs(where: { token0: $token0, token1: $token1 }) {
+      id
+      token0 {
+        id
+      }
+      token1 {
+        id
+      }
+      token1Price
+      token0Price
+      totalSupply
+      reserve0
+      reserve1
+    }
+  }
+`;
+
+export const GetPair = gql`
+  query getPair($id: String!) {
+    pair(id: $id) {
       id
       token0 {
         id

--- a/constants/perpetuals.ts
+++ b/constants/perpetuals.ts
@@ -1,0 +1,26 @@
+import assert from "assert";
+// hard coded perpetual info, until theres a better way to get this info
+export const perpetuals = [
+  {
+    // this is a perp kovan contract
+    name: "New Perpetual Contract Test",
+    symbol: "NEW-PERP-TEST",
+    // this is hardcoded to a mainnet uniswap eth usdc pair for now. But in the future we should be able
+    // to derive the market or markets where the synthetic is being traded...
+    market: {
+      type: "uniswap",
+      id: "0xbb2b8038a1640196fbe3e38816f3e67cba72d940",
+      token0: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      token1: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+    },
+  },
+];
+
+export function findInfoByName(name: string | undefined) {
+  assert(name, "requires perpetual name");
+  const result = perpetuals.find(
+    (perp) => perp.name.toLowerCase() == name.toLowerCase()
+  );
+  assert(result, `Unable to find perp info by name: ${name}`);
+  return result;
+}

--- a/constants/perpetuals.ts
+++ b/constants/perpetuals.ts
@@ -5,6 +5,7 @@ export const perpetuals = [
     // this is a perp kovan contract
     name: "New Perpetual Contract Test",
     symbol: "NEW-PERP-TEST",
+    address: "0x24d15f2607ee56dF752375a63e646cbF8E652aF3",
     // this is hardcoded to a mainnet uniswap eth usdc pair for now. But in the future we should be able
     // to derive the market or markets where the synthetic is being traded...
     market: {
@@ -22,5 +23,14 @@ export function findInfoByName(name: string | undefined) {
     (perp) => perp.name.toLowerCase() == name.toLowerCase()
   );
   assert(result, `Unable to find perp info by name: ${name}`);
+  return result;
+}
+
+export function findInfoByAddress(address: string | undefined) {
+  assert(address, "requires perpetual address");
+  const result = perpetuals.find(
+    (perp) => perp.address.toLowerCase() == address.toLowerCase()
+  );
+  assert(result, `Unable to find perp info by address: ${address}`);
   return result;
 }

--- a/containers/PerpetualState.ts
+++ b/containers/PerpetualState.ts
@@ -1,0 +1,59 @@
+import { createContainer } from "unstated-next";
+import { useState, useEffect } from "react";
+import { BigNumber, Bytes, ethers } from "ethers";
+
+import Connection from "./Connection";
+import SelectedContract from "./SelectedContract";
+import EmpContract from "./EmpContract";
+import EmpState from "./EmpState";
+import { getAbi } from "../utils/getAbi";
+
+type Provider = ethers.providers.Provider | ethers.Signer;
+
+export async function getPerpetualState(address: string, provider: Provider) {
+  const abi = getAbi("perpetual", "2");
+  const contract = new ethers.Contract(address, abi, provider);
+  return {
+    fundingRate: await contract.fundingRate(),
+    priceIdentifier: await contract.priceIdentifier(),
+  };
+}
+
+type dataType = {
+  fundingRate: {
+    rate: BigNumber;
+  };
+  priceIdentifier: string;
+};
+const useContractState = () => {
+  const { signer } = Connection.useContainer();
+  const abi = getAbi("perpetual", "2");
+  const { address, isValid } = SelectedContract.useContainer();
+  const [state, setState] = useState<{
+    data: dataType | null;
+    error: Error | null;
+  }>({ data: null, error: null });
+  const [loading, setLoading] = useState<boolean>(true);
+  useEffect(() => {
+    if (!isValid) return;
+    if (!address) return;
+    if (!signer) return;
+    getPerpetualState(address, signer)
+      .then((data) => {
+        setState({ ...state, data });
+      })
+      .catch((error) => {
+        setState({ ...state, error });
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [address, isValid, signer]);
+
+  return {
+    ...state,
+    loading,
+  };
+};
+
+export default createContainer(useContractState);

--- a/containers/PerpetualState.ts
+++ b/containers/PerpetualState.ts
@@ -35,9 +35,7 @@ const useContractState = () => {
   }>({ data: null, error: null });
   const [loading, setLoading] = useState<boolean>(true);
   useEffect(() => {
-    if (!isValid) return;
-    if (!address) return;
-    if (!signer) return;
+    if (!isValid || !address || !signer) return;
     getPerpetualState(address, signer)
       .then((data) => {
         setState({ ...state, data });

--- a/containers/Uniswap.ts
+++ b/containers/Uniswap.ts
@@ -1,20 +1,48 @@
+import { createContainer } from "unstated-next";
 import { useState, useEffect } from "react";
 
-import { useQuery } from "@apollo/client";
-import { PAIR } from "../apollo/uniswap/queries";
+import { useApolloClient, ApolloClient } from "@apollo/client";
+import { GetPair } from "../apollo/uniswap/queries";
 
-const useUniswap = ({ token0, token1 }: { token0: string; token1: string }) => {
-  const { loading, error, data } = useQuery(PAIR, {
+import { findInfoByName } from "../constants/perpetuals";
+import SelectedContract from "../containers/SelectedContract";
+
+function call(client: any, query: any, variables: any) {
+  return client.query({
+    query,
     context: { clientName: "UNISWAP" },
-    variables: { token0, token1 },
-    pollInterval: 60000,
+    variables,
   });
+}
+
+function getPair() {
+  const client = useApolloClient();
+  const { contract, isValid } = SelectedContract.useContainer();
+  const [loading, setLoading] = useState<boolean>(true);
+  const [data, setData] = useState<any | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!contract?.name) return;
+    if (!isValid) return;
+    if (!client) return;
+    try {
+      const info = findInfoByName(contract.name);
+      call(client, GetPair, { id: info.market.id })
+        .then((result: any) => setData(result.data))
+        .catch(setError)
+        .finally(() => setLoading(false));
+    } catch (err) {
+      setError(err);
+      setLoading(false);
+    }
+  }, [contract, client]);
 
   return {
     loading,
-    error,
     data,
+    error,
   };
-};
+}
 
-export default useUniswap;
+export const UniswapGetPair = createContainer(getPair);

--- a/containers/Uniswap.ts
+++ b/containers/Uniswap.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useApolloClient, ApolloClient } from "@apollo/client";
 import { GetPair } from "../apollo/uniswap/queries";
 
-import { findInfoByName } from "../constants/perpetuals";
+import { findInfoByAddress } from "../constants/perpetuals";
 import SelectedContract from "../containers/SelectedContract";
 
 function call(client: any, query: any, variables: any) {
@@ -17,17 +17,16 @@ function call(client: any, query: any, variables: any) {
 
 function getPair() {
   const client = useApolloClient();
-  const { contract, isValid } = SelectedContract.useContainer();
+  const { address, isValid } = SelectedContract.useContainer();
   const [loading, setLoading] = useState<boolean>(true);
   const [data, setData] = useState<any | null>(null);
   const [error, setError] = useState<Error | null>(null);
-
   useEffect(() => {
-    if (!contract?.name) return;
+    if (!address) return;
     if (!isValid) return;
     if (!client) return;
     try {
-      const info = findInfoByName(contract.name);
+      const info = findInfoByAddress(address);
       call(client, GetPair, { id: info.market.id })
         .then((result: any) => setData(result.data))
         .catch(setError)
@@ -36,7 +35,7 @@ function getPair() {
       setError(err);
       setLoading(false);
     }
-  }, [contract, client]);
+  }, [address, client]);
 
   return {
     loading,

--- a/features/contract-selector/ContractSelector.tsx
+++ b/features/contract-selector/ContractSelector.tsx
@@ -13,7 +13,6 @@ import { withStyles, useTheme } from "@material-ui/core/styles";
 import ContractList from "../../containers/ContractList";
 import SelectedContract from "../../containers/SelectedContract";
 import Connection from "../../containers/Connection";
-import Uniswap from "../../containers/Uniswap";
 
 const BootstrapInput = withStyles((theme) => ({
   root: {

--- a/features/contract-state/TabbedView.tsx
+++ b/features/contract-state/TabbedView.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useCallback } from "react";
+import styled from "styled-components";
+import {
+  Container,
+  Box,
+  Typography,
+  Tab,
+  Tabs,
+  Hidden,
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  Grid,
+} from "@material-ui/core";
+import MenuIcon from "@material-ui/icons/Menu";
+
+import ContractState from "./ContractState";
+
+import EmpState from "../../features/contract-state/ContractState";
+import ManagePosition from "../../features/manage-position/ManagePosition";
+import AllPositions from "../../features/all-positions/AllPositions";
+import Weth from "../../features/weth/Weth";
+import Yield from "../../features/yield/Yield";
+import Analytics from "../../features/analytics/Analytics";
+
+import { ContractInfo } from "../../containers/ContractList";
+import Collateral from "../../containers/Collateral";
+import Token from "../../containers/Token";
+import WethContract from "../../containers/WethContract";
+
+import { YIELD_TOKENS } from "../../constants/yieldTokens";
+
+const StyledTabs = styled(Tabs)`
+  & .MuiTabs-flexContainer {
+    border-bottom: 1px solid #999;
+    width: 200%;
+  }
+  & .Mui-selected {
+    font-weight: bold;
+  }
+  padding-bottom: 2rem;
+`;
+
+const Blurb = styled.div`
+  padding: 1rem;
+  border: 1px solid #434343;
+`;
+
+export default function ({ contract }: { contract: ContractInfo }) {
+  const { address } = contract;
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedMenuItem, setSelectedMenuItem] = useState<string>(
+    "General Info"
+  );
+  const [options, setOptions] = useState<Array<string>>([]);
+  const { address: collAddress } = Collateral.useContainer();
+  const { address: tokenAddress } = Token.useContainer();
+  const { contract: weth } = WethContract.useContainer();
+  const isYieldToken =
+    tokenAddress &&
+    Object.keys(YIELD_TOKENS).includes(tokenAddress.toLowerCase());
+
+  const buildOptionsList = () => {
+    // Default list that all contracts have.
+    let menuOptions = ["General Info", "Manage Position", "All Positions"];
+    // If it is weth collateral contract then add the weth option.
+    if (weth && collAddress?.toLowerCase() == weth.address.toLowerCase()) {
+      menuOptions.push("Wrap/Unwrap WETH");
+    }
+
+    // If it is a yield token then add the yUSD yield and analytics tabs.
+    if (isYieldToken) {
+      menuOptions = menuOptions.concat(["yUSD Yield", "Analytics"]);
+    }
+
+    // Update selected page if the user toggles between EMPs while selected on
+    // invalid pages (i.e on Wrap/Unwrap then moves to uUSDrBTC).
+    if (menuOptions.indexOf(selectedMenuItem) == -1) {
+      setSelectedMenuItem("General Info");
+    }
+    return menuOptions;
+  };
+
+  useEffect(() => {
+    setOptions(buildOptionsList());
+  }, [address, weth, collAddress, isYieldToken, selectedMenuItem]);
+
+  const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuItemClick = (index: number) => {
+    setAnchorEl(null);
+    setSelectedMenuItem(options[index]);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <>
+      <Hidden only={["sm", "xs"]}>
+        <StyledTabs
+          value={options.indexOf(selectedMenuItem)}
+          onChange={(_, index) => handleMenuItemClick(index)}
+        >
+          {options.map((option, index) => (
+            <Tab key={index} label={option} disableRipple />
+          ))}
+        </StyledTabs>
+      </Hidden>
+      <Hidden only={["md", "lg", "xl"]}>
+        <div>
+          <Box pt={1} pb={2}>
+            <Grid container spacing={2}>
+              <Grid item>
+                <Button variant="outlined" onClick={handleClickListItem}>
+                  <MenuIcon />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Typography style={{ marginTop: `8px` }}>
+                  <strong>Current page:</strong> {selectedMenuItem}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Box>
+          <Menu
+            anchorEl={anchorEl}
+            keepMounted
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+          >
+            {options.map((option, index) => (
+              <MenuItem
+                key={index}
+                selected={index === options.indexOf(selectedMenuItem)}
+                onClick={(_) => handleMenuItemClick(index)}
+              >
+                {option}
+              </MenuItem>
+            ))}
+          </Menu>
+        </div>
+      </Hidden>
+      {selectedMenuItem === "General Info" && (
+        <>
+          <Blurb>
+            <Typography>
+              The Expiring Multi Party (EMP) is{" "}
+              <a
+                href="https://umaproject.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                UMA
+              </a>
+              's most current financial smart contract template. This UI is a
+              community-made tool to make interfacing with the protocol easier,
+              please use at your own risk. The source code can be viewed{" "}
+              <a
+                href="https://github.com/UMAprotocol/emp-tools"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                here
+              </a>
+              . UMA's main Github can be viewed{" "}
+              <a
+                href="https://github.com/UMAprotocol/protocol"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                here
+              </a>
+              .
+            </Typography>
+          </Blurb>
+          <EmpState />
+        </>
+      )}
+      {selectedMenuItem === "Manage Position" && <ManagePosition />}
+      {selectedMenuItem === "All Positions" && <AllPositions />}
+      {selectedMenuItem === "yUSD Yield" && <Yield />}
+      {selectedMenuItem === "Wrap/Unwrap WETH" && <Weth />}
+      {selectedMenuItem === "Analytics" && <Analytics />}
+    </>
+  );
+}

--- a/features/perpetual/contract-state/ContractState.tsx
+++ b/features/perpetual/contract-state/ContractState.tsx
@@ -1,7 +1,6 @@
 import { Box, Grid, Typography } from "@material-ui/core";
 import styled from "styled-components";
 import GeneralInfo from "./GeneralInfo";
-import Totals from "../../core/Totals";
 import { PerpetualInfo } from "./PerpetualInfo";
 
 const Important = styled(Typography)`
@@ -48,9 +47,6 @@ const White = styled.span`
 const ContractState = () => {
   return (
     <Box pt={4}>
-      <Grid container spacing={4}>
-        <Totals />
-      </Grid>
       <Grid container spacing={4}>
         <PerpetualInfo />
       </Grid>

--- a/features/perpetual/contract-state/ContractState.tsx
+++ b/features/perpetual/contract-state/ContractState.tsx
@@ -2,6 +2,7 @@ import { Box, Grid, Typography } from "@material-ui/core";
 import styled from "styled-components";
 import GeneralInfo from "./GeneralInfo";
 import Totals from "../../core/Totals";
+import { PerpetualInfo } from "./PerpetualInfo";
 
 const Important = styled(Typography)`
   color: red;
@@ -10,11 +11,48 @@ const Important = styled(Typography)`
   margin-bottom: 20px;
 `;
 
+const DataBox = styled(Box)`
+  border: 1px solid #434343;
+  padding: 1rem 1rem;
+  margin: 1rem 1rem;
+`;
+
+const Label = styled.div`
+  color: #999999;
+`;
+
+const Small = styled.span`
+  font-size: 1rem;
+`;
+
+const LinksContainer = styled.div`
+  color: #999;
+`;
+
+const SmallLink = styled.a`
+  color: white;
+
+  &:not(:first-child) {
+    margin-left: 12px;
+  }
+
+  &:hover {
+    color: red;
+  }
+`;
+
+const White = styled.span`
+  color: white;
+`;
+
 const ContractState = () => {
   return (
     <Box pt={4}>
       <Grid container spacing={4}>
         <Totals />
+      </Grid>
+      <Grid container spacing={4}>
+        <PerpetualInfo />
       </Grid>
       <Box pt={4}>
         <Grid container spacing={3}>

--- a/features/perpetual/contract-state/PerpetualInfo.tsx
+++ b/features/perpetual/contract-state/PerpetualInfo.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { Box, Grid, Typography } from "@material-ui/core";
 import styled from "styled-components";
 import { UniswapGetPair } from "../../../containers/Uniswap";
-import { findInfoByName } from "../../../constants/perpetuals";
 import PerpetualState from "../../../containers/PerpetualState";
 import { utils } from "ethers";
 import { calculateFairValue } from "../../../utils/calculators";
@@ -87,8 +86,6 @@ export function PerpetualInfo() {
     data: uniData,
   } = UniswapGetPair.useContainer();
 
-  console.log({ data, error, uniData, uniLoading, uniError });
-
   // Show loading when we dont have all our info yet
   if (error || !data || uniLoading || uniError) {
     return <PerpetualInfoLoading />;
@@ -99,7 +96,6 @@ export function PerpetualInfo() {
     uniData?.pair?.token0Price
   ).toString();
 
-  console.log({ priceIdentifier, fairValue });
   return (
     <PerpetualInfoView
       marketPrice={[

--- a/features/perpetual/contract-state/PerpetualInfo.tsx
+++ b/features/perpetual/contract-state/PerpetualInfo.tsx
@@ -1,0 +1,88 @@
+import { Box, Grid, Typography } from "@material-ui/core";
+import styled from "styled-components";
+import PriceFeed from "../../../containers/PriceFeed";
+import EmpState from "../../../containers/EmpState";
+import { utils } from "ethers";
+const parseBytes32String = utils.parseBytes32String;
+
+const Label = styled.div`
+  color: #999999;
+`;
+
+const Small = styled.span`
+  font-size: 1rem;
+`;
+
+const DataBox = styled(Box)`
+  border: 1px solid #434343;
+  padding: 1rem 1rem;
+  margin: 1rem 1rem;
+`;
+
+export type PerpetualInfoViewType = {
+  fairValue: [string, string];
+  marketPrice: [string, string];
+  fundingRate: [string, string];
+};
+export function PerpetualInfoView({
+  fairValue,
+  marketPrice,
+  fundingRate,
+}: PerpetualInfoViewType) {
+  return (
+    <Grid container spacing={0}>
+      <Grid item md={4} xs={12}>
+        <DataBox>
+          <Typography variant="h4">
+            <strong>{fairValue[0]}</strong>
+            <Small> {fairValue[1]}</Small>
+          </Typography>
+          <Label>Fair Value</Label>
+        </DataBox>
+      </Grid>
+      <Grid item md={4} xs={12}>
+        <DataBox>
+          <Typography variant="h4">
+            <strong>{marketPrice[0]}</strong>
+            <Small> {marketPrice[1]}</Small>
+          </Typography>
+          <Label>Market Price</Label>
+        </DataBox>
+      </Grid>
+      <Grid item md={4} xs={12}>
+        <DataBox>
+          <Typography variant="h4">
+            <strong>{fundingRate[0]}</strong>
+            <Small> {fundingRate[1]}</Small>
+          </Typography>
+          <Label>Funding Rate</Label>
+        </DataBox>
+      </Grid>
+    </Grid>
+  );
+}
+
+// TODO: calculate fair market value and funding rate from Uni/Bal/Sushi
+export function PerpetualInfo() {
+  const { latestPrice } = PriceFeed.useContainer();
+  const { empState } = EmpState.useContainer();
+
+  // Show loading when we dont have all our info yet
+  if (!empState?.priceIdentifier || !latestPrice) {
+    return (
+      <PerpetualInfoView
+        fairValue={["Loading...", ""]}
+        marketPrice={["Loading...", ""]}
+        fundingRate={["Loading...", ""]}
+      />
+    );
+  }
+  const priceIdentifier = parseBytes32String(empState.priceIdentifier);
+  return (
+    <PerpetualInfoView
+      fairValue={["$123", priceIdentifier]}
+      marketPrice={["$" + latestPrice.toFixed(5), priceIdentifier]}
+      fundingRate={[".0140%", priceIdentifier]}
+    />
+  );
+}

--- a/features/perpetual/contract-state/TabbedView.tsx
+++ b/features/perpetual/contract-state/TabbedView.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from "react";
+import styled from "styled-components";
+import {
+  Container,
+  Box,
+  Typography,
+  Tab,
+  Tabs,
+  Hidden,
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  Grid,
+} from "@material-ui/core";
+import MenuIcon from "@material-ui/icons/Menu";
+
+import { ContractInfo } from "../../../containers/ContractList";
+import ContractState from "./ContractState";
+
+const StyledTabs = styled(Tabs)`
+  & .MuiTabs-flexContainer {
+    border-bottom: 1px solid #999;
+    width: 200%;
+  }
+  & .Mui-selected {
+    font-weight: bold;
+  }
+  padding-bottom: 2rem;
+`;
+
+const Blurb = styled.div`
+  padding: 1rem;
+  border: 1px solid #434343;
+`;
+
+export default function ({ contract }: { contract: ContractInfo }) {
+  let options = ["General Info"];
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedMenuItem, setSelectedMenuItem] = useState<string>(
+    "General Info"
+  );
+  const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const handleMenuItemClick = (index: number) => {
+    setAnchorEl(null);
+    setSelectedMenuItem(options[index]);
+  };
+  return (
+    <>
+      <Hidden only={["sm", "xs"]}>
+        <StyledTabs
+          value={options.indexOf(selectedMenuItem)}
+          onChange={(_, index) => handleMenuItemClick(index)}
+        >
+          {options.map((option, index) => (
+            <Tab key={index} label={option} disableRipple />
+          ))}
+        </StyledTabs>
+      </Hidden>
+      <Hidden only={["md", "lg", "xl"]}>
+        <div>
+          <Box pt={1} pb={2}>
+            <Grid container spacing={2}>
+              <Grid item>
+                <Button variant="outlined" onClick={handleClickListItem}>
+                  <MenuIcon />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Typography style={{ marginTop: `8px` }}>
+                  <strong>Current page:</strong> {selectedMenuItem}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Box>
+          <Menu
+            anchorEl={anchorEl}
+            keepMounted
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+          >
+            {options.map((option, index) => (
+              <MenuItem
+                key={index}
+                selected={index === options.indexOf(selectedMenuItem)}
+                onClick={(_) => handleMenuItemClick(index)}
+              >
+                {option}
+              </MenuItem>
+            ))}
+          </Menu>
+        </div>
+      </Hidden>
+      {selectedMenuItem === "General Info" && (
+        <>
+          <Blurb>
+            <Typography>
+              The Perpetual (Perp) is{" "}
+              <a
+                href="https://umaproject.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                UMA
+              </a>
+              's most current financial smart contract template. This UI is a
+              community-made tool to make interfacing with the protocol easier,
+              please use at your own risk. The source code can be viewed{" "}
+              <a
+                href="https://github.com/UMAprotocol/emp-tools"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                here
+              </a>
+              . UMA's main Github can be viewed{" "}
+              <a
+                href="https://github.com/UMAprotocol/protocol"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                here
+              </a>
+              .
+            </Typography>
+          </Blurb>
+          <ContractState />
+        </>
+      )}
+    </>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,9 +21,10 @@ import Balancer from "../containers/Balancer";
 import DvmContracts from "../containers/DvmContracts";
 import DvmState from "../containers/DvmState";
 import DevMining from "../containers/DevMining";
-import Uniswap from "../containers/Uniswap";
+import { UniswapGetPair } from "../containers/Uniswap";
 import ContractList from "../containers/ContractList";
 import ContractState from "../containers/ContractState";
+import PerpetualState from "../containers/PerpetualState";
 
 import { ApolloProvider } from "@apollo/client";
 import { client } from "../apollo/client";
@@ -53,7 +54,11 @@ const WithStateContainerProviders = ({ children }: IProps) => (
                                     <DvmContracts.Provider>
                                       <DvmState.Provider>
                                         <DevMining.Provider>
-                                          {children}
+                                          <PerpetualState.Provider>
+                                            <UniswapGetPair.Provider>
+                                              {children}
+                                            </UniswapGetPair.Provider>
+                                          </PerpetualState.Provider>
                                         </DevMining.Provider>
                                       </DvmState.Provider>
                                     </DvmContracts.Provider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,290 +17,21 @@ import {
 import MenuIcon from "@material-ui/icons/Menu";
 
 import Header from "../features/core/Header";
-import Weth from "../features/weth/Weth";
-import Yield from "../features/yield/Yield";
-import Analytics from "../features/analytics/Analytics";
-
-// EMP features
-import EmpState from "../features/contract-state/ContractState";
-import ManagePosition from "../features/manage-position/ManagePosition";
-import ContractSelector from "../features/contract-selector/ContractSelector";
-import AllPositions from "../features/all-positions/AllPositions";
-
-import PerpetualState from "../features/perpetual/contract-state/ContractState";
-
-import SelectedContract from "../containers/SelectedContract";
-import Collateral from "../containers/Collateral";
-import Token from "../containers/Token";
-import WethContract from "../containers/WethContract";
-
-import { YIELD_TOKENS } from "../constants/yieldTokens";
 
 import GitHubIcon from "@material-ui/icons/GitHub";
 import TwitterIcon from "@material-ui/icons/Twitter";
 
 import Connection from "../containers/Connection";
 import { ContractInfo } from "../containers/ContractList";
-
-const StyledTabs = styled(Tabs)`
-  & .MuiTabs-flexContainer {
-    border-bottom: 1px solid #999;
-    width: 200%;
-  }
-  & .Mui-selected {
-    font-weight: bold;
-  }
-  padding-bottom: 2rem;
-`;
+import SelectedContract from "../containers/SelectedContract";
+import ContractSelector from "../features/contract-selector/ContractSelector";
+import PerpetualTabbedView from "../features/perpetual/contract-state/TabbedView";
+import EmpTabbedView from "../features/contract-state/TabbedView";
 
 const Blurb = styled.div`
   padding: 1rem;
   border: 1px solid #434343;
 `;
-
-function PerpMainPage({ contract }: { contract: ContractInfo }) {
-  let options = ["General Info"];
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedMenuItem, setSelectedMenuItem] = useState<string>(
-    "General Info"
-  );
-  const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const handleMenuItemClick = (index: number) => {
-    setAnchorEl(null);
-    setSelectedMenuItem(options[index]);
-  };
-  return (
-    <>
-      <Hidden only={["sm", "xs"]}>
-        <StyledTabs
-          value={options.indexOf(selectedMenuItem)}
-          onChange={(_, index) => handleMenuItemClick(index)}
-        >
-          {options.map((option, index) => (
-            <Tab key={index} label={option} disableRipple />
-          ))}
-        </StyledTabs>
-      </Hidden>
-      <Hidden only={["md", "lg", "xl"]}>
-        <div>
-          <Box pt={1} pb={2}>
-            <Grid container spacing={2}>
-              <Grid item>
-                <Button variant="outlined" onClick={handleClickListItem}>
-                  <MenuIcon />
-                </Button>
-              </Grid>
-              <Grid item>
-                <Typography style={{ marginTop: `8px` }}>
-                  <strong>Current page:</strong> {selectedMenuItem}
-                </Typography>
-              </Grid>
-            </Grid>
-          </Box>
-          <Menu
-            anchorEl={anchorEl}
-            keepMounted
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-          >
-            {options.map((option, index) => (
-              <MenuItem
-                key={index}
-                selected={index === options.indexOf(selectedMenuItem)}
-                onClick={(_) => handleMenuItemClick(index)}
-              >
-                {option}
-              </MenuItem>
-            ))}
-          </Menu>
-        </div>
-      </Hidden>
-      {selectedMenuItem === "General Info" && (
-        <>
-          <Blurb>
-            <Typography>
-              The Perpetual (Perp) is{" "}
-              <a
-                href="https://umaproject.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                UMA
-              </a>
-              's most current financial smart contract template. This UI is a
-              community-made tool to make interfacing with the protocol easier,
-              please use at your own risk. The source code can be viewed{" "}
-              <a
-                href="https://github.com/UMAprotocol/emp-tools"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                here
-              </a>
-              . UMA's main Github can be viewed{" "}
-              <a
-                href="https://github.com/UMAprotocol/protocol"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                here
-              </a>
-              .
-            </Typography>
-          </Blurb>
-          <PerpetualState />
-        </>
-      )}
-    </>
-  );
-}
-
-function EmpMainPage({ contract }: { contract: ContractInfo }) {
-  const { address } = contract;
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedMenuItem, setSelectedMenuItem] = useState<string>(
-    "General Info"
-  );
-  const [options, setOptions] = useState<Array<string>>([]);
-  const { address: collAddress } = Collateral.useContainer();
-  const { address: tokenAddress } = Token.useContainer();
-  const { contract: weth } = WethContract.useContainer();
-  const isYieldToken =
-    tokenAddress &&
-    Object.keys(YIELD_TOKENS).includes(tokenAddress.toLowerCase());
-
-  const buildOptionsList = () => {
-    // Default list that all contracts have.
-    let menuOptions = ["General Info", "Manage Position", "All Positions"];
-    // If it is weth collateral contract then add the weth option.
-    if (weth && collAddress?.toLowerCase() == weth.address.toLowerCase()) {
-      menuOptions.push("Wrap/Unwrap WETH");
-    }
-
-    // If it is a yield token then add the yUSD yield and analytics tabs.
-    if (isYieldToken) {
-      menuOptions = menuOptions.concat(["yUSD Yield", "Analytics"]);
-    }
-
-    // Update selected page if the user toggles between EMPs while selected on
-    // invalid pages (i.e on Wrap/Unwrap then moves to uUSDrBTC).
-    if (menuOptions.indexOf(selectedMenuItem) == -1) {
-      setSelectedMenuItem("General Info");
-    }
-    return menuOptions;
-  };
-
-  useEffect(() => {
-    setOptions(buildOptionsList());
-  }, [address, weth, collAddress, isYieldToken, selectedMenuItem]);
-
-  const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuItemClick = (index: number) => {
-    setAnchorEl(null);
-    setSelectedMenuItem(options[index]);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  return (
-    <>
-      <Hidden only={["sm", "xs"]}>
-        <StyledTabs
-          value={options.indexOf(selectedMenuItem)}
-          onChange={(_, index) => handleMenuItemClick(index)}
-        >
-          {options.map((option, index) => (
-            <Tab key={index} label={option} disableRipple />
-          ))}
-        </StyledTabs>
-      </Hidden>
-      <Hidden only={["md", "lg", "xl"]}>
-        <div>
-          <Box pt={1} pb={2}>
-            <Grid container spacing={2}>
-              <Grid item>
-                <Button variant="outlined" onClick={handleClickListItem}>
-                  <MenuIcon />
-                </Button>
-              </Grid>
-              <Grid item>
-                <Typography style={{ marginTop: `8px` }}>
-                  <strong>Current page:</strong> {selectedMenuItem}
-                </Typography>
-              </Grid>
-            </Grid>
-          </Box>
-          <Menu
-            anchorEl={anchorEl}
-            keepMounted
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-          >
-            {options.map((option, index) => (
-              <MenuItem
-                key={index}
-                selected={index === options.indexOf(selectedMenuItem)}
-                onClick={(_) => handleMenuItemClick(index)}
-              >
-                {option}
-              </MenuItem>
-            ))}
-          </Menu>
-        </div>
-      </Hidden>
-      {selectedMenuItem === "General Info" && (
-        <>
-          <Blurb>
-            <Typography>
-              The Expiring Multi Party (EMP) is{" "}
-              <a
-                href="https://umaproject.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                UMA
-              </a>
-              's most current financial smart contract template. This UI is a
-              community-made tool to make interfacing with the protocol easier,
-              please use at your own risk. The source code can be viewed{" "}
-              <a
-                href="https://github.com/UMAprotocol/emp-tools"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                here
-              </a>
-              . UMA's main Github can be viewed{" "}
-              <a
-                href="https://github.com/UMAprotocol/protocol"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                here
-              </a>
-              .
-            </Typography>
-          </Blurb>
-          <EmpState />
-        </>
-      )}
-      {selectedMenuItem === "Manage Position" && <ManagePosition />}
-      {selectedMenuItem === "All Positions" && <AllPositions />}
-      {selectedMenuItem === "yUSD Yield" && <Yield />}
-      {selectedMenuItem === "Wrap/Unwrap WETH" && <Weth />}
-      {selectedMenuItem === "Analytics" && <Analytics />}
-    </>
-  );
-}
 
 function NoContractPage() {
   const { signer } = Connection.useContainer();
@@ -325,9 +56,9 @@ export default function Index() {
     if (contract == null) return <NoContractPage />;
     switch (contract.type) {
       case "Perpetual":
-        return <PerpMainPage contract={contract} />;
+        return <PerpetualTabbedView contract={contract} />;
       case "EMP":
-        return <EmpMainPage contract={contract} />;
+        return <EmpTabbedView contract={contract} />;
       default:
         return <NoContractPage />;
     }

--- a/utils/Contracts.ts
+++ b/utils/Contracts.ts
@@ -18,7 +18,8 @@ export const Contracts: { [networkId: number]: ContractArguments[] } = {
   ].reverse() as ContractArguments[],
   42: [
     ["0x3366b8549047C66E985EcC43026ceD3E831e46A9", "EMP", "1"], // uUSDrBTC Kovan Sep20
-    ["0xFb70A4CBD537B36e647553C279a93E969b041DF0", "Perpetual", "2"], //"Perpetual", yUSD Kovan Oct30
+    ["0xFb70A4CBD537B36e647553C279a93E969b041DF0", "EMP", "1"],
+    ["0x24d15f2607ee56dF752375a63e646cbF8E652aF3", "Perpetual", "2"], //"Perpetual", Test Contract
     ["0xA000Dfe84A1852865d5231e0F6CBF0De08888abE", "EMP", "1"], // uUSDrBTC Kovan Oct20
     ["0x10E3866b5F52d847F24aaAA14BcAd22b74CC14e2", "EMP", "1"], // uUSDrBTC Kovan Nov20
     ["0x3d7d563F4679C750e462Eae4271d2bd84dF66060", "EMP", "1"], // uUSDrETH Kovan Nov20

--- a/utils/calculators.ts
+++ b/utils/calculators.ts
@@ -169,10 +169,13 @@ export function DevMiningCalculator({
 }
 
 export function calculateFairValue(
+  // Funding rate is expected to be returned from perp contract in Wei
   fundingRate: BigNumber,
+  // Market price is expected to be returned in normal decimals. Future adjustment to handling decimals may be needed.
   marketPrice: string
 ) {
   // convert market price to wei from a numerical string in eth
   const marketPriceWei = parseEther(parseFloat(marketPrice).toFixed(18));
+  // Convert back to normal decimal number after multiplication
   return fromWei(marketPriceWei.mul(fundingRate));
 }

--- a/utils/calculators.ts
+++ b/utils/calculators.ts
@@ -1,3 +1,5 @@
+import { utils, BigNumber } from "ethers";
+const { parseEther, formatUnits: fromWei } = utils;
 // https://www.calculatorsoup.com/calculators/financial/compound-interest-calculator.php
 // Calculates a compounding interest, leaving this in as potential useful function
 export const calcInterest = (
@@ -164,4 +166,13 @@ export function DevMiningCalculator({
       calculateEmpValue,
     },
   };
+}
+
+export function calculateFairValue(
+  fundingRate: BigNumber,
+  marketPrice: string
+) {
+  // convert market price to wei from a numerical string in eth
+  const marketPriceWei = parseEther(parseFloat(marketPrice).toFixed(18));
+  return fromWei(marketPriceWei.mul(fundingRate));
 }


### PR DESCRIPTION
# Motivation
#204 

# Summary
- Add perp specific boxes for fair value, funding rate and market price
- adds helper utilities for uniswap gql calls
- clears out perp general info component and totals due to incompatibility with emp state

This needs a lot more work to be production ready, but this is for future work.
- custom containers for getting perp specific state for the general info component
- fixing existing containers to not fetch data based on emp abis 
- position managment tab

# Screenshots
![image](https://user-images.githubusercontent.com/4429761/111836930-7ce52f80-88cd-11eb-966f-bd3f5c3114f5.png)

