### PR TITLE
feat: get emp v2 contract state working

### DIFF
--- a/containers/ContractList.ts
+++ b/containers/ContractList.ts
@@ -98,5 +98,4 @@ const useContractList = () => {
   };
 };
 
-const ContractList = createContainer(useContractList);
-export default ContractList;
+export default createContainer(useContractList);

--- a/containers/ContractState.ts
+++ b/containers/ContractState.ts
@@ -42,7 +42,6 @@ const useContractState = () => {
   function updateState() {
     if (!contract || !signer) return;
     setLoading(true);
-    setData(initState);
     getState(contract, signer)
       .then(setData)
       .catch(setError)

--- a/containers/ContractState.ts
+++ b/containers/ContractState.ts
@@ -1,0 +1,66 @@
+import { createContainer } from "unstated-next";
+import { useState, useEffect } from "react";
+import { BigNumber, Bytes, Contract } from "ethers";
+
+import Connection from "./Connection";
+import EmpContract from "./EmpContract";
+import SelectedContract from "./SelectedContract";
+import { ContractInfo } from "./ContractList";
+import { getState } from "../utils/getAbi";
+
+const initState = {
+  expirationTimestamp: null,
+  collateralCurrency: null,
+  priceIdentifier: null,
+  tokenCurrency: null,
+  collateralRequirement: null,
+  disputeBondPct: null,
+  disputerDisputeRewardPct: null,
+  sponsorDisputeRewardPct: null,
+  minSponsorTokens: null,
+  timerAddress: null,
+  cumulativeFeeMultiplier: null,
+  rawTotalPositionCollateral: null,
+  totalTokensOutstanding: null,
+  liquidationLiveness: null,
+  withdrawalLiveness: null,
+  currentTime: null,
+  isExpired: null,
+  contractState: null,
+  finderAddress: null,
+  expiryPrice: null,
+};
+
+const useContractState = () => {
+  const { block$, signer } = Connection.useContainer();
+  const { contract } = SelectedContract.useContainer();
+
+  const [data, setData] = useState<any>(initState);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  function updateState() {
+    if (!contract || !signer) return;
+    setLoading(true);
+    setData(initState);
+    getState(contract, signer)
+      .then(setData)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }
+  // get state on setting of contract
+  useEffect(() => {
+    updateState();
+  }, [contract, signer]);
+
+  // get state on each block
+  useEffect(() => {
+    if (!block$) return;
+    const sub = block$.subscribe(() => updateState());
+    return () => sub.unsubscribe();
+  }, [block$, signer, contract]);
+
+  return { data, error, loading };
+};
+
+export default createContainer(useContractState);

--- a/containers/EmpContract.ts
+++ b/containers/EmpContract.ts
@@ -1,29 +1,30 @@
 import { createContainer } from "unstated-next";
 import { useState, useEffect } from "react";
 import { ethers } from "ethers";
-import uma from "@studydefi/money-legos/uma";
+import { getAbi } from "../utils/getAbi";
 
-import EmpAddress from "./EmpAddress";
+import SelectedContract from "./SelectedContract";
 import Connection from "./Connection";
 
 function useContract() {
   const { signer } = Connection.useContainer();
-  const { empAddress, isValid } = EmpAddress.useContainer();
+  const {
+    contract: selectedContract,
+    isValid,
+  } = SelectedContract.useContainer();
   const [contract, setContract] = useState<ethers.Contract | null>(null);
 
   useEffect(() => {
-    if (empAddress === null) {
+    if (!selectedContract || !isValid) {
       setContract(null);
+      return;
     }
-    if (empAddress && isValid && signer) {
-      const instance = new ethers.Contract(
-        empAddress,
-        uma.expiringMultiParty.abi,
-        signer
-      );
-      setContract(instance);
-    }
-  }, [empAddress, isValid, signer]);
+    if (!signer) return;
+    const { type, version, address } = selectedContract;
+    const abi = getAbi(type, version);
+    const instance = new ethers.Contract(address, abi, signer);
+    setContract(instance);
+  }, [selectedContract, isValid, signer]);
 
   return { contract };
 }

--- a/containers/EmpState.ts
+++ b/containers/EmpState.ts
@@ -1,134 +1,14 @@
 import { createContainer } from "unstated-next";
-import { useState, useEffect } from "react";
-import { BigNumber, Bytes } from "ethers";
+import ContractState from "./ContractState";
 
-import Connection from "./Connection";
-import EmpContract from "./EmpContract";
-
-interface ContractState {
-  expirationTimestamp: BigNumber | null;
-  collateralCurrency: string | null;
-  priceIdentifier: Bytes | null;
-  tokenCurrency: string | null;
-  collateralRequirement: BigNumber | null;
-  disputeBondPct: BigNumber | null;
-  disputerDisputeRewardPct: BigNumber | null;
-  sponsorDisputeRewardPct: BigNumber | null;
-  minSponsorTokens: BigNumber | null;
-  timerAddress: string | null;
-  cumulativeFeeMultiplier: BigNumber | null;
-  rawTotalPositionCollateral: BigNumber | null;
-  totalTokensOutstanding: BigNumber | null;
-  liquidationLiveness: BigNumber | null;
-  withdrawalLiveness: BigNumber | null;
-  currentTime: BigNumber | null;
-  isExpired: boolean | null;
-  contractState: number | null;
-  finderAddress: string | null;
-  expiryPrice: BigNumber | null;
-}
-
-const initState = {
-  expirationTimestamp: null,
-  collateralCurrency: null,
-  priceIdentifier: null,
-  tokenCurrency: null,
-  collateralRequirement: null,
-  disputeBondPct: null,
-  disputerDisputeRewardPct: null,
-  sponsorDisputeRewardPct: null,
-  minSponsorTokens: null,
-  timerAddress: null,
-  cumulativeFeeMultiplier: null,
-  rawTotalPositionCollateral: null,
-  totalTokensOutstanding: null,
-  liquidationLiveness: null,
-  withdrawalLiveness: null,
-  currentTime: null,
-  isExpired: null,
-  contractState: null,
-  finderAddress: null,
-  expiryPrice: null,
-};
-
-const useContractState = () => {
-  const { block$ } = Connection.useContainer();
-  const { contract: emp } = EmpContract.useContainer();
-
-  const [state, setState] = useState<ContractState>(initState);
-
-  // get state from EMP
-  const queryState = async () => {
-    if (emp === null) {
-      setState(initState);
-    }
-    if (emp) {
-      // have to do this ugly thing because we want to call in parallel
-      const res = await Promise.all([
-        emp.expirationTimestamp(),
-        emp.collateralCurrency(),
-        emp.priceIdentifier(),
-        emp.tokenCurrency(),
-        emp.collateralRequirement(),
-        emp.disputeBondPct(),
-        emp.disputerDisputeRewardPct(),
-        emp.sponsorDisputeRewardPct(),
-        emp.minSponsorTokens(),
-        emp.timerAddress(),
-        emp.cumulativeFeeMultiplier(),
-        emp.rawTotalPositionCollateral(),
-        emp.totalTokensOutstanding(),
-        emp.liquidationLiveness(),
-        emp.withdrawalLiveness(),
-        emp.getCurrentTime(),
-        emp.contractState(),
-        emp.finder(),
-        emp.expiryPrice(),
-      ]);
-
-      const newState: ContractState = {
-        expirationTimestamp: res[0] as BigNumber,
-        collateralCurrency: res[1] as string, // address
-        priceIdentifier: res[2] as Bytes,
-        tokenCurrency: res[3] as string, // address
-        collateralRequirement: res[4] as BigNumber,
-        disputeBondPct: res[5] as BigNumber,
-        disputerDisputeRewardPct: res[6] as BigNumber,
-        sponsorDisputeRewardPct: res[7] as BigNumber,
-        minSponsorTokens: res[8] as BigNumber,
-        timerAddress: res[9] as string, // address
-        cumulativeFeeMultiplier: res[10] as BigNumber,
-        rawTotalPositionCollateral: res[11] as BigNumber,
-        totalTokensOutstanding: res[12] as BigNumber,
-        liquidationLiveness: res[13] as BigNumber,
-        withdrawalLiveness: res[14] as BigNumber,
-        currentTime: res[15] as BigNumber,
-        isExpired: Number(res[15]) >= Number(res[0]),
-        contractState: Number(res[16]),
-        finderAddress: res[17] as string, // address
-        expiryPrice: res[18] as BigNumber,
-      };
-
-      setState(newState);
-    }
+// This wraps the more general contract state for backward compatibility with previous components
+const useEmpState = () => {
+  const { data, error, loading } = ContractState.useContainer();
+  return {
+    empState: data,
+    error,
+    loading,
   };
-
-  // get state on setting of contract
-  useEffect(() => {
-    queryState();
-  }, [emp]);
-
-  // get state on each block
-  useEffect(() => {
-    if (block$ && emp) {
-      const sub = block$.subscribe(() => queryState());
-      return () => sub.unsubscribe();
-    }
-  }, [block$, emp]);
-
-  return { empState: state };
 };
 
-const EmpState = createContainer(useContractState);
-
-export default EmpState;
+export default createContainer(useEmpState);

--- a/containers/SelectedContract.ts
+++ b/containers/SelectedContract.ts
@@ -4,18 +4,23 @@ import { useRouter } from "next/router";
 import { ethers } from "ethers";
 import ContractList, { ContractInfo } from "./ContractList";
 
+export type SelectedContractStateType = {
+  address: string | null;
+  contract: ContractInfo | null;
+  isValid: boolean;
+};
+
 function useSelectedContract() {
   const router = useRouter();
   const { getByAddress, loading } = ContractList.useContainer();
-  const [state, setState] = useState<{
-    address: string | null;
-    contract: ContractInfo | null;
-    isValid: boolean;
-  }>({ address: null, contract: null, isValid: false });
+  const [state, setState] = useState<SelectedContractStateType>({
+    address: null,
+    contract: null,
+    isValid: false,
+  });
 
   // this seeds the address based on URL query param. Should probably be its own hook.
   useEffect(() => {
-    // we need to wait until the contract list is loaded
     if (loading) return;
     const queryAddress = router.query.address;
     const isNewAddress = queryAddress !== state.address;
@@ -39,6 +44,7 @@ function useSelectedContract() {
 
   // Change our globally selected address.
   function setAddress(address: string | null) {
+    setState({ isValid: false, address: null, contract: null });
     let contract = null;
     if (address != null) {
       contract = getByAddress(address) || null;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,6 +23,7 @@ import DvmState from "../containers/DvmState";
 import DevMining from "../containers/DevMining";
 import Uniswap from "../containers/Uniswap";
 import ContractList from "../containers/ContractList";
+import ContractState from "../containers/ContractState";
 
 import { ApolloProvider } from "@apollo/client";
 import { client } from "../apollo/client";
@@ -35,39 +36,41 @@ const WithStateContainerProviders = ({ children }: IProps) => (
   <ApolloProvider client={client}>
     <Connection.Provider>
       <EmpAddress.Provider>
-        <EmpContract.Provider>
-          <WethContract.Provider>
-            <EmpState.Provider>
-              <Token.Provider>
-                <Collateral.Provider>
-                  <PriceFeed.Provider>
-                    <EmpSponsors.Provider>
-                      <Totals.Provider>
-                        <Etherscan.Provider>
-                          <Position.Provider>
-                            <Balancer.Provider>
-                              <DvmContracts.Provider>
-                                <DvmState.Provider>
-                                  <DevMining.Provider>
-                                    <ContractList.Provider>
-                                      <SelectedContract.Provider>
-                                        {children}
-                                      </SelectedContract.Provider>
-                                    </ContractList.Provider>
-                                  </DevMining.Provider>
-                                </DvmState.Provider>
-                              </DvmContracts.Provider>
-                            </Balancer.Provider>
-                          </Position.Provider>
-                        </Etherscan.Provider>
-                      </Totals.Provider>
-                    </EmpSponsors.Provider>
-                  </PriceFeed.Provider>
-                </Collateral.Provider>
-              </Token.Provider>
-            </EmpState.Provider>
-          </WethContract.Provider>
-        </EmpContract.Provider>
+        <ContractList.Provider>
+          <SelectedContract.Provider>
+            <EmpContract.Provider>
+              <WethContract.Provider>
+                <ContractState.Provider>
+                  <EmpState.Provider>
+                    <Token.Provider>
+                      <Collateral.Provider>
+                        <PriceFeed.Provider>
+                          <EmpSponsors.Provider>
+                            <Totals.Provider>
+                              <Etherscan.Provider>
+                                <Position.Provider>
+                                  <Balancer.Provider>
+                                    <DvmContracts.Provider>
+                                      <DvmState.Provider>
+                                        <DevMining.Provider>
+                                          {children}
+                                        </DevMining.Provider>
+                                      </DvmState.Provider>
+                                    </DvmContracts.Provider>
+                                  </Balancer.Provider>
+                                </Position.Provider>
+                              </Etherscan.Provider>
+                            </Totals.Provider>
+                          </EmpSponsors.Provider>
+                        </PriceFeed.Provider>
+                      </Collateral.Provider>
+                    </Token.Provider>
+                  </EmpState.Provider>
+                </ContractState.Provider>
+              </WethContract.Provider>
+            </EmpContract.Provider>
+          </SelectedContract.Provider>
+        </ContractList.Provider>
       </EmpAddress.Provider>
     </Connection.Provider>
   </ApolloProvider>

--- a/utils/Contracts.ts
+++ b/utils/Contracts.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 // Export contracts in the form [address, type, version]
 // See getAbi file for full list of versions and types available
 export type ContractArguments = [string, string, string];
@@ -12,6 +13,7 @@ export const Contracts: { [networkId: number]: ContractArguments[] } = {
     ["0x3605Ec11BA7bD208501cbb24cd890bC58D2dbA56", "EMP", "1"], // uUSDwETH-DEC
     ["0xE4256C47a3b27a969F25de8BEf44eCA5F2552bD5", "EMP", "1"], // YD-ETH-MAR21
     ["0x1c3f1A342c8D9591D9759220d114C685FD1cF6b8", "EMP", "1"], // YD-BTC-MAR21
+    ["0xd9af2d7E4cF86aAfBCf688a47Bd6b95Da9F7c838", "EMP", "2"], // YD-BTC-JUNE21
   ],
   42: [
     ["0x3366b8549047C66E985EcC43026ceD3E831e46A9", "EMP", "1"], // uUSDrBTC Kovan Sep20
@@ -20,4 +22,16 @@ export const Contracts: { [networkId: number]: ContractArguments[] } = {
     ["0x10E3866b5F52d847F24aaAA14BcAd22b74CC14e2", "EMP", "1"], // uUSDrBTC Kovan Nov20
     ["0x3d7d563F4679C750e462Eae4271d2bd84dF66060", "EMP", "1"], // uUSDrETH Kovan Nov20
   ],
+};
+
+export const getByAddress = (address: string, network: number) => {
+  assert(Contracts[network], "Invalid Network: " + network);
+  const found = Contracts[network].find((info: ContractArguments) => {
+    return info[0].toLowerCase() === address.toLowerCase();
+  });
+  assert(
+    found,
+    `No contract found by network ${network} and address ${address}`
+  );
+  return found;
 };

--- a/utils/getAbi.ts
+++ b/utils/getAbi.ts
@@ -18,6 +18,7 @@ type ContractType = {
   abi: any[];
   getState?: (instance: Contract) => Promise<any>;
 };
+
 export const Contracts: ContractType[] = [
   {
     // we could include semver to do compatibilty checks for version strings, but it would add to bundle and this is good enough
@@ -25,30 +26,12 @@ export const Contracts: ContractType[] = [
     types: ["EMP", "ExpiringMultiParty"],
     abi: emp1.abi,
     async getState(instance: Contract) {
-      const state = {
-        expirationTimestamp: (await instance.expirationTimestamp()) as BigNumber,
-        collateralCurrency: (await instance.collateralCurrency()) as string, // address
-        priceIdentifier: (await instance.priceIdentifier()) as Bytes,
-        tokenCurrency: (await instance.tokenCurrency()) as string, // address
-        collateralRequirement: (await instance.collateralRequirement()) as BigNumber,
+      return {
+        ...(await commonEmpState(instance)),
         disputeBondPct: (await instance.disputeBondPct()) as BigNumber,
         disputerDisputeRewardPct: (await instance.disputerDisputeRewardPct()) as BigNumber,
         sponsorDisputeRewardPct: (await instance.sponsorDisputeRewardPct()) as BigNumber,
-        minSponsorTokens: (await instance.minSponsorTokens()) as BigNumber,
-        timerAddress: (await instance.timerAddress()) as string, // address
-        cumulativeFeeMultiplier: (await instance.cumulativeFeeMultiplier()) as BigNumber,
-        rawTotalPositionCollateral: (await instance.rawTotalPositionCollateral()) as BigNumber,
-        totalTokensOutstanding: (await instance.totalTokensOutstanding()) as BigNumber,
-        liquidationLiveness: (await instance.liquidationLiveness()) as BigNumber,
-        withdrawalLiveness: (await instance.withdrawalLiveness()) as BigNumber,
-        currentTime: (await instance.getCurrentTime()) as BigNumber,
-        contractState: Number(await instance.contractState()) as number,
-        finderAddress: (await instance.finder()) as string, // address
-        expiryPrice: (await instance.expiryPrice) as BigNumber,
-        isExpired: false,
       };
-      state.isExpired = state.currentTime.gte(state.expirationTimestamp);
-      return state;
     },
   },
   {
@@ -56,30 +39,12 @@ export const Contracts: ContractType[] = [
     types: ["EMP", "ExpiringMultiParty"],
     abi: emp2.abi,
     async getState(instance: Contract) {
-      const state = {
-        expirationTimestamp: (await instance.expirationTimestamp()) as BigNumber,
-        collateralCurrency: (await instance.collateralCurrency()) as string, // address
-        priceIdentifier: (await instance.priceIdentifier()) as Bytes,
-        tokenCurrency: (await instance.tokenCurrency()) as string, // address
-        collateralRequirement: (await instance.collateralRequirement()) as BigNumber,
+      return {
+        ...(await commonEmpState(instance)),
         disputeBondPct: (await instance.disputeBondPercentage()) as BigNumber,
         disputerDisputeRewardPct: (await instance.disputerDisputeRewardPercentage()) as BigNumber,
         sponsorDisputeRewardPct: (await instance.sponsorDisputeRewardPercentage()) as BigNumber,
-        minSponsorTokens: (await instance.minSponsorTokens()) as BigNumber,
-        timerAddress: (await instance.timerAddress()) as string, // address
-        cumulativeFeeMultiplier: (await instance.cumulativeFeeMultiplier()) as BigNumber,
-        rawTotalPositionCollateral: (await instance.rawTotalPositionCollateral()) as BigNumber,
-        totalTokensOutstanding: (await instance.totalTokensOutstanding()) as BigNumber,
-        liquidationLiveness: (await instance.liquidationLiveness()) as BigNumber,
-        withdrawalLiveness: (await instance.withdrawalLiveness()) as BigNumber,
-        currentTime: (await instance.getCurrentTime()) as BigNumber,
-        contractState: Number(await instance.contractState()) as number,
-        finderAddress: (await instance.finder()) as string, // address
-        expiryPrice: (await instance.expiryPrice) as BigNumber,
-        isExpired: false,
       };
-      state.isExpired = state.currentTime.gte(state.expirationTimestamp);
-      return state;
     },
   },
   {
@@ -93,6 +58,31 @@ export const Contracts: ContractType[] = [
     abi: erc20.abi,
   },
 ];
+
+// This helper function for the getState calls for each contract abi version of emp tools
+async function commonEmpState(instance: Contract) {
+  const state = {
+    expirationTimestamp: (await instance.expirationTimestamp()) as BigNumber,
+    collateralCurrency: (await instance.collateralCurrency()) as string, // address
+    priceIdentifier: (await instance.priceIdentifier()) as Bytes,
+    tokenCurrency: (await instance.tokenCurrency()) as string, // address
+    collateralRequirement: (await instance.collateralRequirement()) as BigNumber,
+    minSponsorTokens: (await instance.minSponsorTokens()) as BigNumber,
+    timerAddress: (await instance.timerAddress()) as string, // address
+    cumulativeFeeMultiplier: (await instance.cumulativeFeeMultiplier()) as BigNumber,
+    rawTotalPositionCollateral: (await instance.rawTotalPositionCollateral()) as BigNumber,
+    totalTokensOutstanding: (await instance.totalTokensOutstanding()) as BigNumber,
+    liquidationLiveness: (await instance.liquidationLiveness()) as BigNumber,
+    withdrawalLiveness: (await instance.withdrawalLiveness()) as BigNumber,
+    currentTime: (await instance.getCurrentTime()) as BigNumber,
+    contractState: Number(await instance.contractState()) as number,
+    finderAddress: (await instance.finder()) as string, // address
+    expiryPrice: (await instance.expiryPrice) as BigNumber,
+    isExpired: false,
+  };
+  state.isExpired = state.currentTime.gte(state.expirationTimestamp);
+  return state;
+}
 
 // case insensitive include
 function includes(list: string[], str: string) {

--- a/utils/getAbi.ts
+++ b/utils/getAbi.ts
@@ -1,38 +1,95 @@
 // this file takes cues from commons getAbi utility
 import assert from "assert";
 import { useState, useEffect } from "react";
-import { ethers } from "ethers";
+import { ethers, BigNumber, Bytes, Contract } from "ethers";
 // inelegant imports, but this is the only way afaik to work in browser
 import emp1 from "@uma/core-1-2/build/contracts/ExpiringMultiParty.json";
 import emp2 from "@uma/core-2-0/build/contracts/ExpiringMultiParty.json";
 import perp2 from "@uma/core-2-0/build/contracts/Perpetual.json";
 import erc20 from "@uma/core-2-0/build/contracts/ExpandedERC20.json";
+import { ContractInfo } from "../containers/ContractList";
+
+type Provider = ethers.providers.Web3Provider;
+type Signer = ethers.Signer;
 
 type ContractType = {
   versions: string[];
-  names: string[];
+  types: string[];
   abi: any[];
+  getState?: (instance: Contract) => Promise<any>;
 };
 export const Contracts: ContractType[] = [
   {
     // we could include semver to do compatibilty checks for version strings, but it would add to bundle and this is good enough
     versions: ["1", "1.2.0", "1.2.1", "1.2.2"],
-    names: ["EMP", "ExpiringMultiParty"],
+    types: ["EMP", "ExpiringMultiParty"],
     abi: emp1.abi,
+    async getState(instance: Contract) {
+      const state = {
+        expirationTimestamp: (await instance.expirationTimestamp()) as BigNumber,
+        collateralCurrency: (await instance.collateralCurrency()) as string, // address
+        priceIdentifier: (await instance.priceIdentifier()) as Bytes,
+        tokenCurrency: (await instance.tokenCurrency()) as string, // address
+        collateralRequirement: (await instance.collateralRequirement()) as BigNumber,
+        disputeBondPct: (await instance.disputeBondPct()) as BigNumber,
+        disputerDisputeRewardPct: (await instance.disputerDisputeRewardPct()) as BigNumber,
+        sponsorDisputeRewardPct: (await instance.sponsorDisputeRewardPct()) as BigNumber,
+        minSponsorTokens: (await instance.minSponsorTokens()) as BigNumber,
+        timerAddress: (await instance.timerAddress()) as string, // address
+        cumulativeFeeMultiplier: (await instance.cumulativeFeeMultiplier()) as BigNumber,
+        rawTotalPositionCollateral: (await instance.rawTotalPositionCollateral()) as BigNumber,
+        totalTokensOutstanding: (await instance.totalTokensOutstanding()) as BigNumber,
+        liquidationLiveness: (await instance.liquidationLiveness()) as BigNumber,
+        withdrawalLiveness: (await instance.withdrawalLiveness()) as BigNumber,
+        currentTime: (await instance.getCurrentTime()) as BigNumber,
+        contractState: Number(await instance.contractState()) as number,
+        finderAddress: (await instance.finder()) as string, // address
+        expiryPrice: (await instance.expiryPrice) as BigNumber,
+        isExpired: false,
+      };
+      state.isExpired = state.currentTime.gte(state.expirationTimestamp);
+      return state;
+    },
   },
   {
     versions: ["2", "2.0.0", "2.0.1", "latest"],
-    names: ["EMP", "ExpiringMultiParty"],
+    types: ["EMP", "ExpiringMultiParty"],
     abi: emp2.abi,
+    async getState(instance: Contract) {
+      const state = {
+        expirationTimestamp: (await instance.expirationTimestamp()) as BigNumber,
+        collateralCurrency: (await instance.collateralCurrency()) as string, // address
+        priceIdentifier: (await instance.priceIdentifier()) as Bytes,
+        tokenCurrency: (await instance.tokenCurrency()) as string, // address
+        collateralRequirement: (await instance.collateralRequirement()) as BigNumber,
+        disputeBondPct: (await instance.disputeBondPercentage()) as BigNumber,
+        disputerDisputeRewardPct: (await instance.disputerDisputeRewardPercentage()) as BigNumber,
+        sponsorDisputeRewardPct: (await instance.sponsorDisputeRewardPercentage()) as BigNumber,
+        minSponsorTokens: (await instance.minSponsorTokens()) as BigNumber,
+        timerAddress: (await instance.timerAddress()) as string, // address
+        cumulativeFeeMultiplier: (await instance.cumulativeFeeMultiplier()) as BigNumber,
+        rawTotalPositionCollateral: (await instance.rawTotalPositionCollateral()) as BigNumber,
+        totalTokensOutstanding: (await instance.totalTokensOutstanding()) as BigNumber,
+        liquidationLiveness: (await instance.liquidationLiveness()) as BigNumber,
+        withdrawalLiveness: (await instance.withdrawalLiveness()) as BigNumber,
+        currentTime: (await instance.getCurrentTime()) as BigNumber,
+        contractState: Number(await instance.contractState()) as number,
+        finderAddress: (await instance.finder()) as string, // address
+        expiryPrice: (await instance.expiryPrice) as BigNumber,
+        isExpired: false,
+      };
+      state.isExpired = state.currentTime.gte(state.expirationTimestamp);
+      return state;
+    },
   },
   {
     versions: ["2", "2.0.0", "2.0.1", "latest"],
-    names: ["Perp", "Perpetual"],
+    types: ["Perp", "Perpetual"],
     abi: perp2.abi,
   },
   {
     versions: ["latest"],
-    names: ["Erc20"],
+    types: ["Erc20"],
     abi: erc20.abi,
   },
 ];
@@ -42,18 +99,35 @@ function includes(list: string[], str: string) {
   return list.map((x) => x.toLowerCase()).includes(str);
 }
 
-export function getAbi(name: string, version: string = "latest") {
-  assert(name, "requires a name");
-  name = name.toLowerCase();
+export function get(type: string, version: string = "latest") {
+  assert(type, "requires a type");
+  type = type.toLowerCase();
   version = version.toLowerCase();
   const found = Contracts.find((contract) => {
     return (
-      includes(contract.versions, version) && includes(contract.names, name)
+      includes(contract.versions, version) && includes(contract.types, type)
     );
   });
+  assert(found, `No contract found by type ${type} and version ${version}`);
+  return found;
+}
+
+export function getAbi(type: string, version: string = "latest") {
+  const found = get(type, version);
   assert(
-    found && found.abi,
-    `No contract abi found by name ${name} and version ${version}`
+    found.abi,
+    `No contract abi found by type ${type} and version ${version}`
   );
   return found.abi;
+}
+
+export async function getState(
+  { address, type, version }: ContractInfo,
+  provider: Provider | Signer
+) {
+  const { abi, getState } = get(type, version);
+  assert(abi, "requires abi");
+  assert(getState, "requires getState function");
+  const instance = new ethers.Contract(address, abi, provider);
+  return getState(instance);
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

# motivation
#214

# summary
This allows emp contracts to work with different interfaces, mainly renaming of Pct functions to Percentage.  This switches the EmpState container to use the new and more general ContractState container under the hood. This leverages a new 'getState' function bound to each contract abi to allow both getting and mapping contract state into a form compatible with the views.

Another PR will be needed in order to fix decimalization between synthetic and collateral

