### PR TITLE
fix: add 10 min cache to coingecko calls to prevent rate limit

### DIFF
--- a/utils/getCoinGeckoTokenPrice.ts
+++ b/utils/getCoinGeckoTokenPrice.ts
@@ -7,6 +7,8 @@ const fetchOptions = {
   headers: {
     Accept: "application/json",
     "Content-Type": "application/json",
+    // sets a 10 minute cache, should prevent too many requests to CG
+    "Cache-Control": "max-age=600",
   },
 };
 


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

## Motivation
#222 

## Summary
Adds a caching period of 10 minutes for coingecko fetches.  Maybe this is too long, but I think it would be ok.  I'm seeing better results when loading the page, dev mining calculations seem to work consistently now.

closes #222