### PR TITLE
fix: fix expiryPrice request in emp state causing app crash for expir…

### DIFF
--- a/containers/Token.ts
+++ b/containers/Token.ts
@@ -24,7 +24,7 @@ function useToken() {
   const [balanceBN, setBalanceBN] = useState<BigNumber | null>(null);
 
   const getTokenInfo = async () => {
-    if (contract) {
+    if (contract && address) {
       const symbol: string = await contract.symbol();
       const name: string = await contract.name();
       const decimals: number = await contract.decimals();

--- a/features/manage-position/ManagePosition.tsx
+++ b/features/manage-position/ManagePosition.tsx
@@ -21,17 +21,19 @@ const Manager = () => {
   const { empState } = EmpState.useContainer();
   const { isExpired } = empState;
   const [method, setMethod] = useState<Method>(DEFAULT_METHOD);
+
   const handleChange = (e: React.ChangeEvent<{ value: unknown }>) =>
     setMethod(e.target.value as Method);
 
+  useEffect(() => {
+    setMethod(DEFAULT_METHOD);
+    if (isExpired) {
+      setMethod("settle");
+    }
+  }, [isExpired]);
+
   if (signer !== null && isExpired !== null) {
     // Whenever the expiry state changes, check if we should change the default method.
-    useEffect(() => {
-      setMethod(DEFAULT_METHOD);
-      if (isExpired) {
-        setMethod("settle");
-      }
-    }, [isExpired]);
 
     return (
       <Box my={0}>

--- a/utils/getAbi.ts
+++ b/utils/getAbi.ts
@@ -77,7 +77,7 @@ async function commonEmpState(instance: Contract) {
     currentTime: (await instance.getCurrentTime()) as BigNumber,
     contractState: Number(await instance.contractState()) as number,
     finderAddress: (await instance.finder()) as string, // address
-    expiryPrice: (await instance.expiryPrice) as BigNumber,
+    expiryPrice: (await instance.expiryPrice()) as BigNumber,
     isExpired: false,
   };
   state.isExpired = state.currentTime.gte(state.expirationTimestamp);


### PR DESCRIPTION
…ed contracts

Signed-off-by: David <david@umaproject.org>

# motivation
#225 

# summary
This was caused by calling expiryPrice on the contract instance without actually invoking the function. small typo. various other small fixes found along the way to find the bug. 