### PR TITLE
fix: change subgraph url and adjust query to get positions

### DIFF
--- a/apollo/client.ts
+++ b/apollo/client.ts
@@ -11,7 +11,7 @@ const umaLinkKovan = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/kovan-contracts",
 });
 const umaLinkMainnet = new HttpLink({
-  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma",
+  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/mainnet-contracts",
 });
 const balancerLink = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer",

--- a/apollo/client.ts
+++ b/apollo/client.ts
@@ -8,7 +8,7 @@ import { request } from "http";
 
 // this has the latest subgraph for now, may need to be updated later
 const umaLinkKovan = new HttpLink({
-  uri: "https://api.thegraph.com/subgraphs/name/nicholaspai/kovan-staging",
+  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/kovan-contracts",
 });
 const umaLinkMainnet = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma",

--- a/apollo/client.ts
+++ b/apollo/client.ts
@@ -6,8 +6,9 @@ import {
 } from "@apollo/client";
 import { request } from "http";
 
+// this has the latest subgraph for now, may need to be updated later
 const umaLinkKovan = new HttpLink({
-  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma-kovan",
+  uri: "https://api.thegraph.com/subgraphs/name/nicholaspai/kovan-staging",
 });
 const umaLinkMainnet = new HttpLink({
   uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma",

--- a/apollo/uma/queries.ts
+++ b/apollo/uma/queries.ts
@@ -21,12 +21,8 @@ export const EMP_DATA = gql`
           id
         }
         liquidationId
-        liquidator {
-          address
-        }
-        disputer {
-          address
-        }
+        liquidator
+        disputer
         tokensLiquidated
         lockedCollateral
         liquidatedCollateral

--- a/features/perpetual/contract-state/TabbedView.tsx
+++ b/features/perpetual/contract-state/TabbedView.tsx
@@ -18,6 +18,7 @@ import MenuIcon from "@material-ui/icons/Menu";
 import { ContractInfo } from "../../../containers/ContractList";
 import ContractState from "./ContractState";
 import ManagePosition from "../../../features/manage-position/ManagePosition";
+import AllPositions from "../../../features/all-positions/AllPositions";
 
 const StyledTabs = styled(Tabs)`
   & .MuiTabs-flexContainer {
@@ -36,7 +37,7 @@ const Blurb = styled.div`
 `;
 
 export default function ({ contract }: { contract: ContractInfo }) {
-  let options = ["General Info", "Manage Position"];
+  let options = ["General Info", "Manage Position", "All Positions"];
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedMenuItem, setSelectedMenuItem] = useState<string>(
     "General Info"
@@ -134,6 +135,7 @@ export default function ({ contract }: { contract: ContractInfo }) {
         </>
       )}
       {selectedMenuItem === "Manage Position" && <ManagePosition />}
+      {selectedMenuItem === "All Positions" && <AllPositions />}
     </>
   );
 }


### PR DESCRIPTION
**motivation**
#204 

**summary**
This enables viewing all positions and for adding deposits and liquidating.  This leverages the work @nicholaspai has done with the uma subgraph and is using his recently updated code which supports the perp on kovan.

**screens**
![image](https://user-images.githubusercontent.com/4429761/113422465-c4be8900-939a-11eb-85a9-fef0334af4bb.png)

![image](https://user-images.githubusercontent.com/4429761/113428246-77471980-93a4-11eb-9c49-24844ff78cb5.png)

**issue**
closes #204