### PR TITLE
fix: fix liquidator/disputer addresses to fix modal issue

### DIFF
--- a/containers/EmpSponsors.ts
+++ b/containers/EmpSponsors.ts
@@ -43,8 +43,8 @@ interface LiquidationQuery {
   id: string;
   sponsor: { id: string };
   liquidationId: string;
-  liquidator: { address: string };
-  disputer: { address: string };
+  liquidator: string;
+  disputer: string;
   tokensLiquidated: string;
   lockedCollateral: string;
   liquidatedCollateral: string;
@@ -197,8 +197,8 @@ const useEmpSponsors = () => {
                 const sponsorAddressPlusId = liquidation.id;
                 newLiquidations[sponsorAddressPlusId] = {
                   sponsor: utils.getAddress(liquidation.sponsor.id),
-                  liquidator: liquidation.liquidator?.address,
-                  disputer: liquidation.disputer?.address,
+                  liquidator: liquidation.liquidator,
+                  disputer: liquidation.disputer,
                   liquidationId: liquidation.liquidationId,
                   liquidatedCR: liquidatedCR.toString(),
                   maxDisputablePrice: maxDisputablePrice.toString(),

--- a/features/all-positions/LiquidationActionDialog.tsx
+++ b/features/all-positions/LiquidationActionDialog.tsx
@@ -92,7 +92,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
     return utils.commify(x_string);
   };
 
-  const prettyAddress = (x: String) => {
+  const prettyAddress = (x: String = "") => {
     return x.substr(0, 6) + "..." + x.substr(x.length - 6, x.length);
   };
 
@@ -289,7 +289,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                     )}
                     target="_blank"
                   >
-                    {prettyAddress(liquidatedPosition.liquidationReceipt)}
+                    {prettyAddress(liquidatedPosition.liquidationReceipt || "")}
                   </a>
                 </Status>
                 <Status>
@@ -298,7 +298,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                     href={getEtherscanUrl(liquidatedPosition.sponsor)}
                     target="_blank"
                   >
-                    {prettyAddress(liquidatedPosition.sponsor)}
+                    {prettyAddress(liquidatedPosition.sponsor || "")}
                   </a>
                 </Status>
                 <Status>
@@ -307,7 +307,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                     href={getEtherscanUrl(liquidatedPosition.liquidator)}
                     target="_blank"
                   >
-                    {prettyAddress(liquidatedPosition.liquidator)}
+                    {prettyAddress(liquidatedPosition.liquidator || "")}
                   </a>
                 </Status>
                 <Status>
@@ -317,7 +317,7 @@ const LiquidationActionDialog = (props: DialogProps) => {
                       href={getEtherscanUrl(liquidatedPosition.disputer)}
                       target="_blank"
                     >
-                      {prettyAddress(liquidatedPosition.disputer)}
+                      {prettyAddress(liquidatedPosition.disputer || "")}
                     </a>
                   )}
                   {!liquidatedPosition.disputer && (


### PR DESCRIPTION
fixes #233 
clubhouse: https://app.clubhouse.io/uma-project/story/970/disable-or-hide-the-ability-to-dispute-a-liquidation-from-emp-tools
**summary**
looks like issue was caused by minor change in subgraph api. liquidation and dispute addresses now are on `liquidator` and `disputer` rather than before `liquidator.address` and `disputer.address`